### PR TITLE
Properly bubble errors up the stack

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -156,7 +156,8 @@ Object.assign(Application.prototype, {
                             })
                             .catch(function(err) {
                                 logger.error(err);
-                                throw err;
+                                reject(err);
+                                callback && callback(err);
                             })
 
                     });
@@ -220,7 +221,8 @@ Object.assign(Application.prototype, {
                             })
                             .catch(function(err) {
                                 logger.error(err);
-                                throw err;
+                                reject(err);
+                                callback && callback(err);
                             })
                     }, { stream: options.stream });
                 })
@@ -347,7 +349,8 @@ Object.assign(Application.prototype, {
                         })
                         .catch(function(err) {
                             logger.error(err);
-                            throw err;
+                            reject(err);
+                            callback && callback(err);
                         })
                 }, { stream: options.stream });
 


### PR DESCRIPTION
The throws inside these functions were causing errors to get swallowed. Also added callback handling to the error handlers.