### PR TITLE
Update Lodash Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "3.4.8",
     "express-handlebars": "^3.0.0",
     "follow-redirects": "^1.2.3",
-    "lodash": "~2.4.1",
+    "lodash": "~4.17.4",
     "log4js": "~0.6.9",
     "lru-cache": "^4.0.2",
     "mustache": "^2.3.0",


### PR DESCRIPTION
Old Lodash 2 is incompatible with some of the functions used in schemaobject.js. Simple upgrade appears to resolve these issues.