### PR TITLE
Remove arbitrary LineItemSchema from shared.js

### DIFF
--- a/lib/entities/shared.js
+++ b/lib/entities/shared.js
@@ -43,17 +43,6 @@ module.exports.BrandingScheme = new Entity.SchemaObject({
     CreatedDateUTC: { type: Date }
 });
 
-module.exports.LineItemSchema = new Entity.SchemaObject({
-    Description: { type: String },
-    Quantity: { type: Number },
-    UnitAmount: { type: Number },
-    AccountCode: { type: String },
-    ItemCode: { type: String },
-    TaxType: { type: String },
-    LineAmount: { type: Number },
-    Tracking: { type: String }
-});
-
 var InvoiceIDSchema = new Entity.SchemaObject({
     InvoiceID: { type: String, toObject: 'hasValue' },
     InvoiceNumber: { type: String, toObject: 'hasValue' }


### PR DESCRIPTION
There was two LineItemSchema in shared.js, removed the one with the
incorrect Tracking Type.