### PR TITLE
Add multi item push to fix issue #39

### DIFF
--- a/lib/entity_helpers/accounting/items.js
+++ b/lib/entity_helpers/accounting/items.js
@@ -28,6 +28,16 @@ var Items = EntityHelper.extend({
             id: id
         };
         return this.deleteEntities(options);
+    },
+    saveItems: function(items, options) {
+        return this.saveEntities(items, this.setUpOptions(options));
+    },
+    setUpOptions: function(options) {
+        var self = this;
+        var clonedOptions = _.clone(options || {});
+        clonedOptions.entityPath = 'Items.Item';
+        clonedOptions.entityConstructor = function(data) { return self.newItem(data) };
+        return clonedOptions;
     }
 })
 

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -1915,6 +1915,23 @@ describe('regression tests', function() {
                 });
         });
 
+        it('saves multiple items', function(done) {
+            var items = [];
+
+            for (var i = 0; i < 10; i++) {
+                items.push(currentApp.core.items.newItem(sampleItem));
+            }
+
+            currentApp.core.items.saveItems(items)
+                .then(function(response) {
+                    expect(response.entities).to.have.length.greaterThan(9);
+                    done();
+                })
+                .catch(function(err) {
+                    done(wrapError(err));
+                })
+        });
+
         it('retrieves some items (no paging)', function(done) {
             currentApp.core.items.getItems()
                 .then(function(items) {

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -280,13 +280,35 @@ describe('regression tests', function() {
             Code: randomString.replace(/-/g, '').substring(0, 10),
             Name: 'Test account from Node SDK ' + randomString,
             Type: 'BANK',
-            BankAccountNumber: '062-021-0000000',
+            BankAccountNumber: '062-123-0000000',
         };
 
         var account = currentApp.core.accounts.newAccount(testAccountData);
 
         return account.save()
             .then(function(response) {
+                var account = response.entities[0];
+                bankAccounts.push({
+                    account: account,
+                    id: account.AccountID
+                });
+            });
+    });
+
+    before('create a sales account', function() {
+        const randomString = uuid.v4();
+
+        var testAccountData = {
+            Code: randomString.replace(/-/g, '').substring(0, 10),
+            Name: 'Test account from Node SDK ' + randomString,
+            Type: 'SALES'
+        };
+
+        var account = currentApp.core.accounts.newAccount(testAccountData);
+
+        return account.save()
+            .then(function(response) {
+                expect(response.entities.length).to.be.greaterThan(0);
                 var account = response.entities[0];
                 bankAccounts.push({
                     account: account,
@@ -1919,6 +1941,7 @@ describe('regression tests', function() {
             var items = [];
 
             for (var i = 0; i < 10; i++) {
+                sampleItem.Code = 'Item-' + Math.random();
                 items.push(currentApp.core.items.newItem(sampleItem));
             }
 
@@ -2029,7 +2052,7 @@ describe('regression tests', function() {
             var modifiedAfter = new Date();
 
             //take 20 seconds ago as we just created a contact
-            modifiedAfter.setTime(modifiedAfter.getTime() - 20000);
+            modifiedAfter.setTime(modifiedAfter.getTime() - 60000);
 
             currentApp.core.contacts.getContacts({ modifiedAfter: modifiedAfter })
                 .then(function(contacts) {
@@ -2327,6 +2350,24 @@ describe('regression tests', function() {
                     done(wrapError(err));
                 })
         })
+        it('get - modifiedAfter', function(done) {
+            var modifiedAfter = new Date();
+
+            //take 20 seconds ago as we just created a contact
+            modifiedAfter.setTime(modifiedAfter.getTime() - 60000);
+
+            currentApp.core.manualjournals.getManualJournals({ modifiedAfter: modifiedAfter })
+                .then(function(manualjournals) {
+                    expect(manualjournals.length).to.equal(1);
+                    done();
+
+                })
+                .catch(function(err) {
+                    console.log(util.inspect(err, null, null));
+                    done(wrapError(err));
+                })
+
+        })
 
         it('get (no paging)', function(done) {
             currentApp.core.manualjournals.getManualJournals()
@@ -2378,24 +2419,6 @@ describe('regression tests', function() {
                     console.log(util.inspect(err, null, null));
                     done(wrapError(err));
                 })
-        })
-        it('get - modifiedAfter', function(done) {
-            var modifiedAfter = new Date();
-
-            //take 20 seconds ago as we just created a contact
-            modifiedAfter.setTime(modifiedAfter.getTime() - 30000);
-
-            currentApp.core.manualjournals.getManualJournals({ modifiedAfter: modifiedAfter })
-                .then(function(manualjournals) {
-                    expect(manualjournals.length).to.equal(1);
-                    done();
-
-                })
-                .catch(function(err) {
-                    console.log(util.inspect(err, null, null));
-                    done(wrapError(err));
-                })
-
         })
 
         it('get - invalid modified date', function(done) {


### PR DESCRIPTION
Add support for multi item push using the following code:

```
       var sampleItem = {
            Code: 'Item-' + Math.random(),
            Name: 'Fully Tracked Item',
            Description: '2014 Merino Sweater',
            PurchaseDescription: '2014 Merino Sweater',
            PurchaseDetails: {
                UnitPrice: 149.00,
                AccountCode: salesAccount
            },
            SalesDetails: {
                UnitPrice: 299.00,
                AccountCode: salesAccount
            }
        };            
            
            var items = [];

            for (var i = 0; i < 10; i++) {
                sampleItem.Code = 'Item-' + Math.random();
                items.push(currentApp.core.items.newItem(sampleItem));
            }

            currentApp.core.items.saveItems(items)
                .then(function(response) {
                    expect(response.entities).to.have.length.greaterThan(9);
                    done();
                })
                .catch(function(err) {
                    done(wrapError(err));
                })
```

