### PR TITLE
Add LineItemID to LineItem schema

### DIFF
--- a/lib/entities/accounting/invoice.js
+++ b/lib/entities/accounting/invoice.js
@@ -16,7 +16,7 @@ var InvoiceSchema = new Entity.SchemaObject({
     InvoiceNumber: { type: String, toObject: 'hasValue' },
     Reference: { type: String, toObject: 'hasValue' },
     BrandingThemeID: { type: String, toObject: 'hasValue' },
-    URL: { type: String, toObject: 'hasValue' },
+    Url: { type: String, toObject: 'hasValue' },
     CurrencyCode: { type: String, toObject: 'hasValue' },
     CurrencyRate: { type: Number, toObject: 'hasValue' },
     Status: { type: String, toObject: 'hasValue' },

--- a/lib/entities/shared.js
+++ b/lib/entities/shared.js
@@ -89,6 +89,7 @@ var TrackingCategorySchema = new Entity.SchemaObject({
 });
 
 module.exports.LineItemSchema = new Entity.SchemaObject({
+    LineItemID: { type: String },
     Description: { type: String },
     Quantity: { type: Number },
     UnitAmount: { type: Number },


### PR DESCRIPTION
This attribute appeared to be missing from the schema as per [the Xero docs](https://developer.xero.com/documentation/api/invoices#LineItems). Additionally, the Url attribute in the invoice schema was mistakenly capitalised. 