### PR TITLE
Add support for the IncludeOnline parameter in Attachment saving

### DIFF
--- a/docs/Attachments.md
+++ b/docs/Attachments.md
@@ -24,7 +24,7 @@ This helper contains the following functions:
 The `Attachment` object also provides the following method:
 
 * `getContent(writestream)`
-* `save(ownerpath, data[, stream])`
+* `save(ownerpath, data[, stream, includeOnline])`
 
 ### Creating a new attachment using a file stream (recommended)
 
@@ -58,6 +58,7 @@ Some points to note with the code snippet above:
 * The `.save()` function returns a promise that can be met using the `.then()` function, and rejections can be caught using the `.catch()` function.
 * The promise that is returned by the `.save()` function contains a response object.  This has a bunch of information about the state of the response, but also contains an `entities` array.  This array is what actually contains the object that was just created. 
 * For single object saving, this `entities` array should only ever contain one element, but some objects support a multiple object save and in this case the `entities` array will contain all of the objects that were created.
+* The `includeOnline` parameter is only effective for invoice attachments and defaults to `false`. This is used to distinguish which attachments should be exposed to the invoice recipient via the Xero online invoice viewer.
 
 ### Creating a new attachment using a file reference
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -123,6 +123,11 @@ Object.assign(Application.prototype, {
                     if (options.unitdp)
                         params.unitdp = options.unitdp;
 
+                    //Added to support attachments POST/PUT for invoices
+                    //being included on the online invoice
+                    if (options.includeOnline)
+                      params.IncludeOnline = 'true';
+
                     var endPointUrl = options.api === 'payroll' ? self.options.payrollAPIEndPointUrl : self.options.coreAPIEndPointUrl;
                     var url = self.options.baseUrl + endPointUrl + path;
                     if (!_.isEmpty(params))

--- a/lib/entities/accounting/attachment.js
+++ b/lib/entities/accounting/attachment.js
@@ -21,9 +21,10 @@ var Attachment = Entity.extend(AttachmentSchema, {
     getContent: function(writeStream) {
         return this.application.core.attachments.getContent(this, writeStream);
     },
-    save: function(ownerPath, data, stream) {
+    save: function(ownerPath, data, stream, include) {
         var self = this;
         var path = ownerPath + '/Attachments/' + this.FileName;
+        var includeOnline = include || false;
 
         if (!stream) {
             //we'll assume data is not a file stream, so we'll create one
@@ -37,6 +38,7 @@ var Attachment = Entity.extend(AttachmentSchema, {
         var options = {
             contentType: this.MimeType,
             entityPath: 'Attachments.Attachment',
+            includeOnline: includeOnline,
             entityConstructor: function(data) {
                 return self.application.core.attachments.newAttachment(data);
             }


### PR DESCRIPTION
There was no observed way to utilise the parameter IncludeOnline when saving an attachment to an invoice, nor any way for the existing Save method to collect a value for it. As such, I've added a parameter to the save function that defaults to false (including when undefined) which should maintain API compatibility. The Xero API defaults to false for this parameter, hence the part in putOrPost only sets it if true.