### PR TITLE
Fix for #69. Convert oauth errors to JSON

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -134,7 +134,15 @@ Object.assign(Application.prototype, {
                     var contentType = options.contentType || 'application/json';
 
                     self.oa[method](url, self.options.accessToken, self.options.accessSecret, payload, contentType, function(err, data, res) {
-                        data = JSON.parse(data);
+                        try {
+                          data = JSON.parse(data);
+                        } catch (ex) {
+                          // data could not be parsed as JSON, it's likely because of an oauth error
+                          data = qs.parse(data);
+                        } finally {
+
+                        }
+
                         if (err && data && data['ErrorNumber'] >= 0) {
                             var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode);
                             errObj.data = data;
@@ -189,8 +197,12 @@ Object.assign(Application.prototype, {
             self.checkExpiry()
                 .then(function() {
                     self.oa.delete(url, self.options.accessToken, self.options.accessSecret, function(err, data, res) {
-                        if (data)
-                            data = JSON.parse(data);
+                        try {
+                          data = JSON.parse(data);
+                        } catch (ex) {
+                          // data could not be parsed as JSON, it's likely because of an oauth error
+                          data = qs.parse(data);
+                        }
 
                         if (options.stream && !err) {
                             // Already done
@@ -215,7 +227,6 @@ Object.assign(Application.prototype, {
                         if (!data || data === "") {
                             return resolve();
                         }
-
 
                         var ret = { response: data, res: res };
                         resolve(ret);
@@ -301,48 +312,53 @@ Object.assign(Application.prototype, {
                 }
 
                 self.oa.get(url, self.options.accessToken, self.options.accessSecret, function(err, data, res) {
-                    data = JSON.parse(data)
 
-                    if (options.stream && !err) {
-                        // Already done
-                        return resolve();
-                    }
-                    if (err && data) {
-                        var errObj = new Error('GET call failed with: ' + err.statusCode);
-                        errObj.data = data;
-                        reject(errObj);
-                        callback && callback(errObj);
-                        return;
-                    }
+                  try {
+                    data = JSON.parse(data);
+                  } catch (ex) {
+                    // data could not be parsed as JSON, it's likely because of an oauth error
+                    data = qs.parse(data);
+                  }
 
+                  if (options.stream && !err) {
+                      // Already done
+                      return resolve();
+                  }
 
-                    var ret = { response: data, res: res };
-                    if (err) {
-                        var errObj = new Error('GET call failed with: ' + err.statusCode + ' and exception: ' + JSON.stringify(data.ApiException, null, 2));
-                        reject(errObj);
-                        callback && callback(errObj);
-                        return;
-                    }
+                  if (err && data) {
+                      var errObj = new Error('GET call failed with: ' + err.statusCode);
+                      errObj.data = data;
+                      reject(errObj);
+                      callback && callback(errObj);
+                      return;
+                  }
 
-                    if (options.pager && options.pager.callback) {
-                        options.pager.callback(err, ret, function(err, result) {
-                            result = _.defaults({}, result, { recordCount: 0, stop: false });
-                            if (!result.stop)
-                                getResource(result.nextOffset || ++offset);
-                            else
-                                done();
-                        })
-                        return;
-                    }
+                  var ret = { response: data, res: res };
+                  if (err) {
+                      var errObj = new Error('GET call failed with: ' + err.statusCode + ' and exception: ' + JSON.stringify(data.ApiException, null, 2));
+                      reject(errObj);
+                      callback && callback(errObj);
+                      return;
+                  }
 
-                    done();
+                  if (options.pager && options.pager.callback) {
+                      options.pager.callback(err, ret, function(err, result) {
+                          result = _.defaults({}, result, { recordCount: 0, stop: false });
+                          if (!result.stop)
+                              getResource(result.nextOffset || ++offset);
+                          else
+                              done();
+                      })
+                      return;
+                  }
 
-                    function done() {
-                        resolve(ret);
-                        callback && callback(null, data, res);
-                    }
+                  done();
+
+                  function done() {
+                      resolve(ret);
+                      callback && callback(null, data, res);
+                  }
                 }, { stream: options.stream });
-
             };
         });
     },

--- a/lib/application.js
+++ b/lib/application.js
@@ -139,8 +139,6 @@ Object.assign(Application.prototype, {
                         } catch (ex) {
                           // data could not be parsed as JSON, it's likely because of an oauth error
                           data = qs.parse(data);
-                        } finally {
-
                         }
 
                         if (err && data && data['ErrorNumber'] >= 0) {


### PR DESCRIPTION
This fixes #69 by converting oauth responses which are url encoded to JSON and returns to the consumer.