### PR TITLE
F contactscheme

### DIFF
--- a/lib/entities/shared.js
+++ b/lib/entities/shared.js
@@ -17,9 +17,7 @@ var AddressDetailsSchema = Entity.SchemaObject({
     AddressType: { type: String, toObject: 'always' }
 })
 
-module.exports.AddressSchema = Entity.SchemaObject({
-    Address: { type: AddressDetailsSchema, toObject: 'always' }
-});
+module.exports.AddressSchema = AddressDetailsSchema;
 
 module.exports.PhoneSchema = Entity.SchemaObject({
     PhoneNumber: { type: String, toObject: 'always' },

--- a/lib/entities/shared.js
+++ b/lib/entities/shared.js
@@ -4,7 +4,7 @@ var Entity = require('./entity')
  * ACCOUNTING API SHARED SCHEMAS
  */
 
-var AddressDetailsSchema = Entity.SchemaObject({
+module.exports.AddressSchema = Entity.SchemaObject({
     AddressLine1: { type: String, toObject: 'always' },
     AddressLine2: { type: String, toObject: 'always' },
     AddressLine3: { type: String, toObject: 'always' },
@@ -16,8 +16,6 @@ var AddressDetailsSchema = Entity.SchemaObject({
     AttentionTo: { type: String, toObject: 'always' },
     AddressType: { type: String, toObject: 'always' }
 })
-
-module.exports.AddressSchema = AddressDetailsSchema;
 
 module.exports.PhoneSchema = Entity.SchemaObject({
     PhoneNumber: { type: String, toObject: 'always' },

--- a/test/core/contacts_tests.js
+++ b/test/core/contacts_tests.js
@@ -14,6 +14,13 @@ describe('contacts', () => {
     Name: `Johnnies Coffee ${Math.random()}`,
     FirstName: 'John',
     LastName: 'Smith',
+    Addresses: [{
+      AddressType: "POBOX",
+      AddressLine1: "P O Box 123",
+      City: "Wellington",
+      PostalCode: "6011",
+      AttentionTo: "Andrea"
+    }]
   };
 
   let contactIDsList = [];
@@ -33,6 +40,10 @@ describe('contacts', () => {
           sampleContact.FirstName
         );
         expect(response.entities[0].LastName).to.equal(sampleContact.LastName);
+
+        expect(response.entities[0].Addresses.filter((address) => {
+          return address.City == sampleContact.Addresses[0].City
+        }).length).to.equal(1);
 
         sampleContact = response.entities[0];
 
@@ -69,7 +80,7 @@ describe('contacts', () => {
           expect(contact.ContactID).to.not.equal('');
           expect(contact.ContactID).to.not.equal(undefined);
 
-          if(contactIDsList.length < 5) {
+          if (contactIDsList.length < 5) {
             contactIDsList.push(contact.ContactID);
           }
         });
@@ -116,7 +127,7 @@ describe('contacts', () => {
         done(wrapError(err));
       });
   });
-  
+
   it('get list of IDs', done => {
     currentApp.core.contacts
       .getContacts({
@@ -128,7 +139,7 @@ describe('contacts', () => {
         contacts.forEach(contact => {
           expect(contact.ContactID).to.be.oneOf(contactIDsList);
         });
-        
+
         done();
       })
       .catch(err => {
@@ -136,7 +147,7 @@ describe('contacts', () => {
         done(wrapError(err));
       });
   });
-  
+
   it('get - invalid modified date', done => {
     currentApp.core.contacts
       .getContacts({ modifiedAfter: 'cats' })
@@ -153,7 +164,7 @@ describe('contacts', () => {
   it('create multiple contacts', done => {
     const contacts = [];
 
-    for (let i = 0; i < 2; i += 1) {
+    for (let i = 0;i < 2;i += 1) {
       contacts.push(
         currentApp.core.contacts.newContact({
           Name: `Johnnies Coffee ${Math.random()}`,
@@ -214,6 +225,7 @@ describe('contacts', () => {
       })
       .then(updatedContact => {
         expect(updatedContact.entities[0].Name).to.equal(newName);
+        expect(updatedContact.entities[0].Addresses.filter((address) => {return address.City == "Melbourne"}).length).to.equal(1);
         done();
       })
       .catch(err => {


### PR DESCRIPTION
This adds test and fixes the issue around the schema for Contact addresses.

Looks like Org address works fine still. @jordanwalsh23  do you know why this still works?

Payroll has their own schemas that have the same names.