### PR TITLE
Issue 12 - Fix for BankTransactions

### DIFF
--- a/lib/entity_helpers/accounting/banktransactions.js
+++ b/lib/entity_helpers/accounting/banktransactions.js
@@ -1,33 +1,40 @@
-var _ = require('lodash'),
-    EntityHelper = require('../entity_helper'),
-    BankTransaction = require('../../entities/accounting/banktransaction').BankTransaction,
-    util = require('util')
+'use strict';
 
-var BankTransactions = EntityHelper.extend({
-    constructor: function(application, options) {
-        EntityHelper.call(this, application, Object.assign({ entityPlural: 'BankTransactions' }, options));
-    },
-    newBankTransaction: function(data, options) {
-        return new BankTransaction(this.application, data, options)
-    },
-    newBankTransactions: function(data) {
-        var that = this;
-        return _.map(data, function(item) {
-            return new BankTransaction(that.application, item, {});
-        });
-    },
-    getBankTransaction: function(id, modifiedAfter) {
-        return this.getBankTransactions({ id: id, modifiedAfter: modifiedAfter })
-            .then(function(bankTransactions) {
-                return _.first(bankTransactions);
-            })
-    },
-    getBankTransactions: function(options) {
-        var self = this;
-        var clonedOptions = _.clone(options || {});
-        clonedOptions.entityConstructor = function(data) { return self.newBankTransaction(data) };
-        return this.getEntities(clonedOptions)
-    }
-})
+const _ = require('lodash');
+const EntityHelper = require('../entity_helper');
+const BankTransaction = require('../../entities/accounting/banktransaction')
+  .BankTransaction;
+
+const BankTransactions = EntityHelper.extend({
+  constructor: function(application, options) {
+    EntityHelper.call(
+      this,
+      application,
+      Object.assign({ entityPlural: 'BankTransactions' }, options)
+    );
+  },
+  newBankTransaction: function(data, options) {
+    return new BankTransaction(this.application, data, options);
+  },
+  saveBankTransactions: function(bankTransactions, options) {
+    return this.saveEntities(bankTransactions, this.setUpOptions(options));
+  },
+  getBankTransaction: function(id, modifiedAfter) {
+    return this.getBankTransactions({ id: id, modifiedAfter: modifiedAfter })
+      .then(function(bankTransactions) {
+        return _.first(bankTransactions);
+      });
+  },
+  getBankTransactions: function(options) {
+    return this.getEntities(this.setUpOptions(options));
+  },
+  setUpOptions: function(options) {
+    var self = this;
+    var clonedOptions = _.clone(options || {});
+    clonedOptions.entityPath = 'BankTransactions';
+    clonedOptions.entityConstructor = function(data) { return self.newBankTransaction(data) };
+    return clonedOptions;
+  },
+});
 
 module.exports = BankTransactions;

--- a/lib/entity_helpers/accounting/banktransfers.js
+++ b/lib/entity_helpers/accounting/banktransfers.js
@@ -1,33 +1,39 @@
-var _ = require('lodash'),
-    EntityHelper = require('../entity_helper'),
-    BankTransfer = require('../../entities/accounting/banktransfer').BankTransfer,
-    util = require('util')
+'use strict';
 
-var BankTransfers = EntityHelper.extend({
-    constructor: function(application, options) {
-        EntityHelper.call(this, application, Object.assign({ entityPlural: 'BankTransfers' }, options));
-    },
-    newBankTransfer: function(data, options) {
-        return new BankTransfer(this.application, data, options)
-    },
-    newBankTransfers: function(data) {
-        var that = this;
-        return _.map(data, function(item) {
-            return new BankTransfer(that.application, item, {});
-        });
-    },
-    getBankTransfer: function(id, modifiedAfter) {
-        return this.getBankTransfers({ id: id, modifiedAfter: modifiedAfter })
-            .then(function(bankTransfers) {
-                return _.first(bankTransfers);
-            })
-    },
-    getBankTransfers: function(options) {
-        var self = this;
-        var clonedOptions = _.clone(options || {});
-        clonedOptions.entityConstructor = function(data) { return self.newBankTransfer(data) };
-        return this.getEntities(clonedOptions)
-    }
-})
+const _ = require('lodash');
+const EntityHelper = require('../entity_helper');
+const BankTransfer = require('../../entities/accounting/banktransfer').BankTransfer;
+
+const BankTransfers = EntityHelper.extend({
+  constructor: function(application, options) {
+    EntityHelper.call(
+      this,
+      application,
+      Object.assign({ entityPlural: 'BankTransfers' }, options)
+    );
+  },
+  newBankTransfer: function(data, options) {
+    return new BankTransfer(this.application, data, options);
+  },
+  saveBankTransfers: function(bankTransfers, options) {
+    return this.saveEntities(bankTransfers, this.setUpOptions(options));
+  },
+  getBankTransfer: function(id, modifiedAfter) {
+    return this.getBankTransfers({
+      id: id,
+      modifiedAfter: modifiedAfter
+    }).then(bankTransfers => _.first(bankTransfers));
+  },
+  getBankTransfers: function(options) {
+    return this.getEntities(this.setUpOptions(options));
+  },
+  setUpOptions: function(options) {
+    var self = this;
+    var clonedOptions = _.clone(options || {});
+    clonedOptions.entityPath = 'BankTransfers';
+    clonedOptions.entityConstructor = function(data) { return self.newBankTransfer(data) };
+    return clonedOptions;
+  },
+});
 
 module.exports = BankTransfers;

--- a/lib/entity_helpers/accounting/users.js
+++ b/lib/entity_helpers/accounting/users.js
@@ -16,10 +16,6 @@ var Users = EntityHelper.extend({
                 return _.first(users);
             })
     },
-    // JWalsh 27 February 2017 - commented as user save is not supported by the v2.0 API.
-    // saveUsers: function(users, options) {
-    //     return this.saveEntities(users, options)
-    // },
     getUsers: function(options) {
         var self = this;
         var clonedOptions = _.clone(options || {});

--- a/test/core/banktransactions_tests.js
+++ b/test/core/banktransactions_tests.js
@@ -103,4 +103,44 @@ describe('bank transactions', () => {
         done(wrapError(err));
       });
   });
+
+  it('create multiple banktransactions', done => {
+    const banktransactions = [];
+
+    for (let i = 0; i < 2; i += 1) {
+      banktransactions.push(
+        currentApp.core.bankTransactions.newBankTransaction({
+          Type: 'SPEND',
+          Contact: {
+            Name: 'Johnny McGibbons',
+          },
+          LineItems: [
+            {
+              Description: 'Annual Bank Account Fee',
+              UnitAmount: Math.random(),
+              AccountCode: expenseAccountCode,
+            },
+          ],
+          BankAccount: {
+            AccountID: bankAccountId,
+          },
+        })
+      );
+    }
+
+    currentApp.core.bankTransactions
+      .saveBankTransactions(banktransactions)
+      .then(response => {
+        expect(response.entities).to.have.length.greaterThan(0);
+        response.entities.forEach(bankTransaction => {
+          expect(bankTransaction.BankTransactionID).to.not.equal('');
+          expect(bankTransaction.BankTransactionID).to.not.equal(undefined);
+        });
+        done();
+      })
+      .catch(err => {
+        console.error(util.inspect(err, null, null));
+        done(wrapError(err));
+      });
+  });
 });

--- a/test/core/banktransfers_tests.js
+++ b/test/core/banktransfers_tests.js
@@ -81,4 +81,37 @@ describe('bank transfers', () => {
         done(wrapError(err));
       });
   });
+
+  it('create multiple bank transfers', done => {
+    const banktransfers = [];
+
+    for (let i = 0; i < 2; i += 1) {
+      banktransfers.push(
+        currentApp.core.bankTransfers.newBankTransfer({
+          FromBankAccount: {
+            Code: bankAccounts[0].Code,
+          },
+          ToBankAccount: {
+            Code: bankAccounts[1].Code,
+          },
+          Amount: `${Math.random()}`,
+        })
+      );
+    }
+
+    currentApp.core.bankTransfers
+      .saveBankTransfers(banktransfers)
+      .then(response => {
+        expect(response.entities).to.have.length.greaterThan(0);
+        response.entities.forEach(banktransfer => {
+          expect(banktransfer.BankTransferID).to.not.equal('');
+          expect(banktransfer.BankTransferID).to.not.equal(undefined);
+        });
+        done();
+      })
+      .catch(err => {
+        console.error(util.inspect(err, null, null));
+        done(wrapError(err));
+      });
+  });
 });


### PR DESCRIPTION
This PR fixes the naming convention in BankTransactions and BankTransfers objects.

It also updates the 'saveAll' functions as they were not working correctly previously.

**Note: This is a breaking change so should have a minor version increment.**