### PR TITLE
Add Support for returning PDF Content

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 'use strict';
 
 const _ = require('lodash');
@@ -262,6 +263,10 @@ Object.assign(Application.prototype, {
             }
 
             if (options.format) {
+              //Make more robust for ways to set the format.
+              if(options.format.startsWith('application/'))
+                self.oa._headers['Accept'] = options.format;
+              else
                 self.oa._headers['Accept'] = 'application/' + options.format;
             } else {
                 self.oa._headers['Accept'] = 'application/json';
@@ -311,9 +316,35 @@ Object.assign(Application.prototype, {
                 }
 
                 self.oa.get(url, self.options.accessToken, self.options.accessSecret, function(err, data, res) {
+                  var contentTypeHeader = (res.headers['content-type']) ? res.headers['content-type'] : "";
+                  var contentType = (contentTypeHeader.indexOf(';') >=0) ?
+                    contentTypeHeader.substr(0, contentTypeHeader.indexOf(';')) : contentTypeHeader;
+
+                  //Check to see if what we got matched what we expected & if we did not cause an error.
+                  if(contentType.toLowerCase() !== res.req._headers['accept']){
+                    err = { statusCode: res.statusCode + " but response content-type of" + contentType + " did not match the Accept Header of " + contentType.toLowerCase() };
+                  }
 
                   try {
-                    data = JSON.parse(data);
+                    switch(contentType){
+                      case 'application/pdf':
+                        //Extract FileName Details
+                        var fileMatches = /filename="([^"]+(INV-\d+)\.pdf)"/i.exec(res.headers['content-disposition']);
+                        //Extract Object Type - TODO: Is there not a better way than this?
+                        var objectMatches = /https:\/\/api\.xero\.com\/api\.xro\/[\d\.]+\/([^\/]+)/i.exec(res.responseUrl);
+                        var returnObject = {};
+                        returnObject[objectMatches[1]] = [{
+                          FileName: fileMatches[1],
+                          InvoiceNumber: fileMatches[2],
+                          PdfContentRaw : data
+                        }];
+                        data = returnObject;
+                        break;
+                      case 'text/xml':
+                      //TODO: Account for this, but I'm not sure about the OAuth Error mentioned in the catch below
+                      default:
+                        data = JSON.parse(data);
+                    }
                   } catch (ex) {
                     // data could not be parsed as JSON, it's likely because of an oauth error
                     data = qs.parse(data);

--- a/lib/entity_helpers/accounting/invoices.js
+++ b/lib/entity_helpers/accounting/invoices.js
@@ -13,8 +13,8 @@ var Invoices = EntityHelper.extend({
     streamInvoice: function(id, format, stream) {
         return this.streamEntity({ id: id, stream: stream, format: 'pdf' });
     },
-    getInvoice: function(id, modifiedAfter, where, order) {
-        return this.getInvoices({ id: id, modifiedAfter: modifiedAfter, where: where, order: order })
+    getInvoice: function(id, modifiedAfter, where, format) {
+        return this.getInvoices({ id: id, modifiedAfter: modifiedAfter, where: where, format: (format) ? format : "json" })
             .then(function(invoices) {
                 return _.first(invoices);
             })


### PR DESCRIPTION
The following exposes the Xero API functionality to return the PDF version of a document. I specifically tested/updated based on Invoices, but this should be usable anywhere else where these calls are used for PDF content.

This included:
- Updating getInvoice to include a "format" parameter
*- I also removed the "order" parameter, since there is no order when only a single result is returned.
- Added more robust checking for the "format" option so that it gives the desired behavior and allows the setting of more formats.
- Setup responses based on the content-type of the results.
- Added error checking to see if the content-type matches the original accept header. 