### PR TITLE
Adds 'statusCode' property to errors returned from API calls

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -144,6 +144,7 @@ Object.assign(Application.prototype, {
 
                         if (err && data && data['ErrorNumber'] >= 0) {
                             var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode);
+                            errObj.statusCode = err.statusCode;
                             errObj.data = data;
                             reject(errObj);
                             callback && callback(errObj);
@@ -157,6 +158,7 @@ Object.assign(Application.prototype, {
                             else if (data.ErrorNumber)
                                 exception = data;
                             var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode + ' and exception: ' + JSON.stringify(exception, null, 2));
+                            errObj.statusCode = err.statusCode;
                             reject(errObj);
                             callback && callback(errObj);
                         } else {
@@ -175,6 +177,7 @@ Object.assign(Application.prototype, {
 
                     if (err && err.data) {
                         var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode);
+                        errObj.statusCode = err.statusCode;
                         errObj.data = err.data;
                         reject(errObj);
                         callback && callback(errObj);
@@ -209,6 +212,7 @@ Object.assign(Application.prototype, {
                         }
                         if (err && data && data['ErrorNumber'] >= 0) {
                             var errObj = new Error('DELETE call failed with: ' + err.statusCode);
+                            errObj.statusCode = err.statusCode;
                             errObj.data = data;
                             reject(errObj);
                             callback && callback(errObj);
@@ -217,6 +221,7 @@ Object.assign(Application.prototype, {
 
                         if (err) {
                             var errObj = new Error('DELETE call failed with: ' + err.statusCode + ' and message: ' + err.data);
+                            errObj.statusCode = err.statusCode;
                             reject(errObj);
                             callback && callback(errObj);
                             return;
@@ -237,6 +242,7 @@ Object.assign(Application.prototype, {
 
                     if (err && err.data) {
                         var errObj = new Error('DELETE call failed with: ' + err.statusCode);
+                        errObj.statusCode = err.statusCode;
                         errObj.data = err.data;
                         reject(errObj);
                         callback && callback(errObj);
@@ -278,6 +284,7 @@ Object.assign(Application.prototype, {
 
                     if (err && err.data) {
                         var errObj = new Error('GET call failed with: ' + err.statusCode);
+                        errObj.statusCode = err.statusCode;
                         errObj.data = err.data;
                         reject(errObj);
                         callback && callback(errObj);
@@ -309,7 +316,7 @@ Object.assign(Application.prototype, {
                 if (options.unitdp) {
                     params.unitdp = options.unitdp;
                 }
-                
+
                 if (!_.isEmpty(params)) {
                     url += '?' + querystring.stringify(params);
                 }
@@ -330,6 +337,7 @@ Object.assign(Application.prototype, {
 
                   if (err && data) {
                       var errObj = new Error('GET call failed with: ' + err.statusCode);
+                      errObj.statusCode = err.statusCode;
                       errObj.data = data;
                       reject(errObj);
                       callback && callback(errObj);
@@ -339,6 +347,7 @@ Object.assign(Application.prototype, {
                   var ret = { response: data, res: res };
                   if (err) {
                       var errObj = new Error('GET call failed with: ' + err.statusCode + ' and exception: ' + JSON.stringify(data.ApiException, null, 2));
+                      errObj.statusCode = err.statusCode;
                       reject(errObj);
                       callback && callback(errObj);
                       return;
@@ -382,6 +391,7 @@ Object.assign(Application.prototype, {
 
                     if (err && err.data) {
                         var errObj = new Error('GET call failed with: ' + err.statusCode);
+                        errObj.statusCode = err.statusCode;
                         errObj.data = err.data;
                         reject(errObj);
                         callback && callback(errObj);
@@ -402,12 +412,14 @@ Object.assign(Application.prototype, {
                       var dataParts = qs.parse(data);
 
                       var errObj = new Error('GET call failed with: ' + err.statusCode);
+                      errObj.statusCode = err.statusCode;
                       errObj.data = dataParts;
                       reject(errObj);
                       callback && callback(errObj);
                       return;
                     } else if(err) {
                       var errObj = new Error('GET call failed with: ' + err.statusCode);
+                      errObj.statusCode = err.statusCode;
                       reject(errObj);
                       callback && callback(errObj);
                       return;

--- a/lib/application.js
+++ b/lib/application.js
@@ -487,7 +487,6 @@ Object.assign(Application.prototype, {
                     return ret.response;
             })
             .catch(function(err) {
-                console.error(err);
                 throw err;
             })
 
@@ -508,7 +507,6 @@ Object.assign(Application.prototype, {
                     return self.convertEntities(ret.response, clonedOptions);
             })
             .catch(function(err) {
-                console.error(err);
                 throw err;
             })
 

--- a/test/core/error_tests.js
+++ b/test/core/error_tests.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const common = require('../common/common');
+const functions = require('../common/functions');
+
+const expect = common.expect;
+const wrapError = functions.wrapError;
+const util = common.util;
+
+const currentApp = common.currentApp;
+
+const nonExistentId = '0B283B87-E2AC-4924-AF49-74CF65A763DA';
+
+describe.only('errors', () => {
+
+  describe('PUT endpoints', () => {
+
+    it('throws an error with data and statusCode 400 when a bad request is made', () => {
+      const contact = currentApp.core.contacts.newContact({ InvalidFields: 'yup!' });
+      return contact
+        .save()
+        .then(response => { throw new Error('expected to throw'); })
+        .catch(err => {
+          expect(err).to.be.instanceof(Error);
+          expect(err.message).to.contain('PUT call failed');
+          expect(err.data).to.be.an('object');
+          expect(err.statusCode).to.equal(400);
+        });
+    });
+
+  });
+
+  describe('POST endpoints', () => {
+
+    it('throws an error with data and statusCode 400 when a bad request is made', () => {
+      const contact = currentApp.core.contacts.newContact({ ContactID: nonExistentId, InvalidFields: 'yup!' });
+      return contact
+        .save()
+        .then(response => { throw new Error('expected to throw'); })
+        .catch(err => {
+          expect(err).to.be.instanceof(Error);
+          expect(err.message).to.contain('POST call failed');
+          expect(err.data).to.be.an('object');
+          expect(err.statusCode).to.equal(400);
+        });
+    });
+
+  });
+
+  describe('DELETE endpoints', () => {
+
+    it('throws an error with data and statusCode 404 when a non-existing ID is specified', () => {
+      return currentApp.core.accounts
+        .deleteAccount('not_a_guid')
+        .then(response => { throw new Error('expected to throw'); })
+        .catch(err => {
+          expect(err).to.be.instanceof(Error);
+          expect(err.message).to.contain('DELETE call failed');
+          expect(err.statusCode).to.equal(404);
+        });
+    });
+
+  });
+
+  describe('GET endpoints', () => {
+
+    it('throws an error with data and statusCode 404 when a non-existing ID is specified', () => {
+      return currentApp.core.contacts
+        .getContact(nonExistentId)
+        .then(response => { throw new Error('expected to throw'); })
+        .catch(err => {
+          expect(err).to.be.instanceof(Error);
+          expect(err.message).to.contain('GET call failed');
+          expect(err.data).to.be.an('object');
+          expect(err.statusCode).to.equal(404);
+        });
+    });
+
+  });
+
+});

--- a/test/core/error_tests.js
+++ b/test/core/error_tests.js
@@ -11,7 +11,7 @@ const currentApp = common.currentApp;
 
 const nonExistentId = '0B283B87-E2AC-4924-AF49-74CF65A763DA';
 
-describe.only('errors', () => {
+describe('errors', () => {
 
   describe('PUT endpoints', () => {
 

--- a/test/core/token_tests.js
+++ b/test/core/token_tests.js
@@ -16,7 +16,7 @@ let eventReceiver = currentApp.eventEmitter;
 
 Browser.waitDuration = '30s';
 
-describe.only('get access for public or partner application', () => {
+describe('get access for public or partner application', () => {
   beforeEach(function() {
     if (metaConfig.APPTYPE === 'PRIVATE') {
       this.skip();

--- a/test/core/token_tests.js
+++ b/test/core/token_tests.js
@@ -16,7 +16,7 @@ let eventReceiver = currentApp.eventEmitter;
 
 Browser.waitDuration = '30s';
 
-describe('get access for public or partner application', () => {
+describe.only('get access for public or partner application', () => {
   beforeEach(function() {
     if (metaConfig.APPTYPE === 'PRIVATE') {
       this.skip();

--- a/test/testrunner.js
+++ b/test/testrunner.js
@@ -72,6 +72,7 @@ describe('Accounting API Tests', () => {
     'linkedtransactions_tests',
     `${__dirname}/core/linkedtransactions_tests.js`
   );
+  importTest('error_tests', `${__dirname}/core/error_tests.js`);
 });
 
 describe.skip('Payroll API Tests', () => {


### PR DESCRIPTION
Adds a `statusCode` property to errors returned from authenticated API calls. This allows consumers to programatically check what the actual http error code was.

Hopefully resolves https://github.com/XeroAPI/xero-node/issues/21

Also removes a couple of unnecessary console.error() calls