### PR TITLE
PR#171 Preserve CurrencyCode when serializing an Accout

### DIFF
--- a/lib/entities/accounting/account.js
+++ b/lib/entities/accounting/account.js
@@ -10,7 +10,7 @@ const AccountSchema = Entity.SchemaObject({
   Status: { type: String, toObject: 'never' },
   Description: { type: String, toObject: 'always' },
   BankAccountType: { type: String, toObject: 'hasValue' },
-  CurrencyCode: { type: String, toObject: 'never' },
+  CurrencyCode: { type: String, toObject: 'hasValue' },
   TaxType: { type: String, toObject: 'always' },
   EnablePaymentsToAccount: { type: Boolean, toObject: 'always' },
   ShowInExpenseClaims: { type: Boolean, toObject: 'always' },

--- a/test/core/accounts_tests.js
+++ b/test/core/accounts_tests.js
@@ -179,7 +179,7 @@ describe('accounts', () => {
     const account = currentApp.core.accounts.newAccount(testBankAccountData);
 
     // make sure things are serialized
-    expect(JSON.parse(JSON.stringify(account))).containSubset({
+    expect(JSON.parse(JSON.stringify(account))).to.deep.equal({
       Code: "SOMECODE",
       Name: "Test account from Node SDK",
       Type: "BANK",

--- a/test/core/accounts_tests.js
+++ b/test/core/accounts_tests.js
@@ -167,6 +167,27 @@ describe('accounts', () => {
       });
   });
 
+  it('BANK ACCOUNT FIELDS SERIALIZED', () => {
+    const testBankAccountData = {
+      Code: "SOMECODE",
+      Name: "Test account from Node SDK",
+      Type: "BANK",
+      CurrencyCode: "CAD",
+      BankAccountNumber: "123452",
+    };
+
+    const account = currentApp.core.accounts.newAccount(testBankAccountData);
+
+    // make sure things are serialized
+    expect(JSON.parse(JSON.stringify(account))).containSubset({
+      Code: "SOMECODE",
+      Name: "Test account from Node SDK",
+      Type: "BANK",
+      CurrencyCode: "CAD",
+      BankAccountNumber: "123452",
+    });
+  });
+
   it('GET ONE', done => {
     currentApp.core.accounts
       .getAccount(testAccountId)


### PR DESCRIPTION
RE: https://github.com/XeroAPI/xero-node/issues/171