### PR TITLE
Set oauthConfig.userAgent from config

### DIFF
--- a/src/internals/BaseAPIClient.ts
+++ b/src/internals/BaseAPIClient.ts
@@ -16,6 +16,7 @@ export interface XeroClientConfiguration {
 	privateKeyPath?: string;
 	privateKeyString?: string;
 	callbackUrl?: string;
+    userAgent?: string;
 }
 
 /**

--- a/src/internals/config-helper.ts
+++ b/src/internals/config-helper.ts
@@ -37,6 +37,7 @@ export function mapConfig(xeroConfig: XeroClientConfiguration, apiConfig: ApiCon
 	const OAUTH_ACCESS_TOKEN_PATH = '/oauth/AccessToken';
 
 	let cert = xeroConfig.privateKeyPath ? getStringFromFile(xeroConfig.privateKeyPath) : null;
+    let userAgentString = xeroConfig.userAgent ? xeroConfig.userAgent : 'NodeJS-XeroAPIClient';
 
 	if (xeroConfig.privateKeyString) {
 		cert = xeroConfig.privateKeyString;
@@ -48,7 +49,7 @@ export function mapConfig(xeroConfig: XeroClientConfiguration, apiConfig: ApiCon
 		oauthRequestTokenPath: OAUTH_REQUEST_TOKEN_PATH,
 		oauthAccessTokenPath: OAUTH_ACCESS_TOKEN_PATH,
 		accept: 'application/json',
-		userAgent: 'NodeJS-XeroAPIClient.' + version + '.' + xeroConfig.consumerKey,
+        userAgent: userAgentString + '.' + version + '.' + xeroConfig.consumerKey,
 		consumerKey: xeroConfig.consumerKey,
 		consumerSecret: xeroConfig.consumerSecret,
 		tenantType: apiConfig.tenantType || null,


### PR DESCRIPTION
Setting the UserAgent to begin with an application specific value is requested as part of Xero app certification (for partner apps).

This change ensures creation of the oauthConfig object uses the userAgent configuration property (if set in the Xero config).  This will correctly set the UserAgent header for requests made to Xero API.

If a value is not provided in the config file, it will fallback to “NodeJS-XeroAPIClient” as the userAgent prefix.

The userAgent will always be suffixed with the xero-node version and the consumerKey value from the config file.

Fixes #244 