### PR TITLE
Add missing ItemCode to LineItem model

### DIFF
--- a/src/AccountingAPI-models.ts
+++ b/src/AccountingAPI-models.ts
@@ -338,6 +338,7 @@ export interface LineItem {
 	Tracking?: Tracking[];
 	Quantity?: number;
 	LineItemID?: string;
+	ItemCode?: string;
 }
 export interface ManualJournal {
 	ManualJournalID?: string;


### PR DESCRIPTION
Just discovered that the `ItemCode` type is missing from the `LineItem` interface in the AccountingAPI models.

I'm not sure if this is intentional or left out by mistake. Just thought I'd create a PR anyway.

See attached Xero documentation for LineItem.

![image](https://user-images.githubusercontent.com/28379549/63157765-42a91180-c04a-11e9-9b3e-bec96580e961.png)