### PR TITLE
Fix 'contacts' methods parameter types

### DIFF
--- a/src/AccountingAPIClient.ts
+++ b/src/AccountingAPIClient.ts
@@ -261,12 +261,12 @@ export class AccountingAPIClient extends BaseAPIClient {
 
 			return this.oauth1Client.get<ContactsResponse>(endpoint, header);
 		},
-		create: async (body: Contact | { Contacts: Contact[] }, args?: { summarizeErrors: boolean }): Promise<ContactsResponse> => {
+		create: async (body: Contact | { Contacts: Contact[] }, args?: { summarizeErrors?: boolean }): Promise<ContactsResponse> => {
 			let endpoint = 'contacts';
 			endpoint += generateQueryString(args, true);
 			return this.oauth1Client.put<ContactsResponse>(endpoint, body);
 		},
-		update: async (body?: Contact | { Contacts: Contact[] }, args?: { ContactID: string, summarizeErrors: boolean }): Promise<ContactsResponse> => {
+		update: async (body: Contact | { Contacts: Contact[] }, args?: { ContactID?: string, summarizeErrors?: boolean }): Promise<ContactsResponse> => {
 			let endpoint = 'contacts';
 
 			if (args && args.ContactID) {


### PR DESCRIPTION
When using xero-node in a Typescript project. Some methods have inconstant types and this causes valid function calls to be marked as invalid by Typescript.

E.g.
```typescript
// tsc error: ContactID is required
xero.contacts.update(body, { summarizeErrors: true });
```