### PR TITLE
add apptype enum

### DIFF
--- a/src/__integration_tests__/helpers/integration.helpers.ts
+++ b/src/__integration_tests__/helpers/integration.helpers.ts
@@ -1,6 +1,6 @@
 import * as  prompt from 'prompt';
 import * as path from 'path';
-import { XeroClientConfiguration } from '../../internals/BaseAPIClient';
+import { XeroClientConfiguration, AppType } from '../../internals/BaseAPIClient';
 
 export async function readLine(stringPrompt: string): Promise<string> {
 	return new Promise<string>((resolve, reject) => {
@@ -17,7 +17,7 @@ export function getPrivateConfig(testPartition?: string): XeroClientConfiguratio
 		return config;
 	} else {
 		return {
-			appType: 'private',
+			appType: AppType.Private,
 			consumerKey: process.env['PrivateConsumerKey' + (testPartition || '')],
 			consumerSecret: process.env['PrivateConsumerKey' + (testPartition || '')],
 			callbackUrl: null,
@@ -45,7 +45,7 @@ export function getPartnerAppConfig() {
 		return config;
 	} else {
 		return {
-			appType: 'partner',
+			appType: AppType.Partner,
 			consumerKey: process.env.PartnerConsumerKey,
 			consumerSecret: process.env.PartnerConsumerSecret,
 			callbackUrl: null,

--- a/src/__tests__/AccountingAPI-attachments.tests.ts
+++ b/src/__tests__/AccountingAPI-attachments.tests.ts
@@ -1,4 +1,4 @@
-import { XeroClientConfiguration } from '../internals/BaseAPIClient';
+import { XeroClientConfiguration, AppType } from '../internals/BaseAPIClient';
 import { IOAuth1HttpClient } from '../internals/OAuth1HttpClient';
 import { AccountingAPIClient } from '../AccountingAPIClient';
 import { validTestCertPath } from '../internals/__tests__/helpers/privateKey-helpers';
@@ -9,7 +9,7 @@ import { IFixture, IEndPointDetails } from './helpers/IFixture';
 const guid1 = 'dcb417fc-0c23-4ba3-bc7f-fbc718e7e663';
 
 const xeroConfig: XeroClientConfiguration = {
-	appType: 'private',
+	appType: AppType.Private,
 	consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 	consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 	privateKeyPath: validTestCertPath()

--- a/src/__tests__/AccountingAPI-endpoint.tests.ts
+++ b/src/__tests__/AccountingAPI-endpoint.tests.ts
@@ -1,4 +1,4 @@
-import { XeroClientConfiguration } from '../internals/BaseAPIClient';
+import { XeroClientConfiguration, AppType } from '../internals/BaseAPIClient';
 import { OAuth1HttpClient } from '../internals/OAuth1HttpClient';
 import { AccountingAPIClient } from '../AccountingAPIClient';
 import { mapState, mapConfig } from '../internals/config-helper';
@@ -11,7 +11,7 @@ describe('AccountingAPI endpoints', () => {
 	const guid2 = '857c9e3f-640a-4df2-99fd-dd0e52a785e7';
 
 	const xeroConfig: XeroClientConfiguration = {
-		appType: 'private',
+		appType: AppType.Private,
 		consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 		consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 		privateKeyPath: validTestCertPath()

--- a/src/__tests__/AccountingAPI-history.tests.ts
+++ b/src/__tests__/AccountingAPI-history.tests.ts
@@ -1,5 +1,5 @@
 import { AccountingAPIClient } from '../AccountingAPIClient';
-import { XeroClientConfiguration } from '../internals/BaseAPIClient';
+import { XeroClientConfiguration, AppType } from '../internals/BaseAPIClient';
 import { OAuth1HttpClient } from '../internals/OAuth1HttpClient';
 import { InMemoryOAuthLibFactoryFactory } from '../internals/__tests__/helpers/InMemoryOAuthLib';
 import { validTestCertPath } from '../internals/__tests__/helpers/privateKey-helpers';
@@ -13,7 +13,7 @@ describe('AccountingAPI history', () => {
 	const guid1 = 'dcb417fc-0c23-4ba3-bc7f-fbc718e7e663';
 
 	const xeroConfig: XeroClientConfiguration = {
-		appType: 'private',
+		appType: AppType.Private,
 		consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 		consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 		privateKeyPath: validTestCertPath()

--- a/src/__tests__/ProjectsAPI-endpoint.tests.ts
+++ b/src/__tests__/ProjectsAPI-endpoint.tests.ts
@@ -1,4 +1,4 @@
-import { XeroClientConfiguration } from '../internals/BaseAPIClient';
+import { XeroClientConfiguration, AppType } from '../internals/BaseAPIClient';
 import { mapConfig, mapState } from '../internals/config-helper';
 import { OAuth1HttpClient } from '../internals/OAuth1HttpClient';
 import { InMemoryOAuthLibFactoryFactory } from '../internals/__tests__/helpers/InMemoryOAuthLib';
@@ -9,7 +9,7 @@ import { IEndPointDetails, IFixture } from './helpers/IFixture';
 describe('ProjectsAPI endpoints', () => {
 
 	const xeroConfig: XeroClientConfiguration = {
-		appType: 'private',
+		appType: AppType.Private,
 		consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 		consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 		privateKeyPath: validTestCertPath()

--- a/src/internals/BaseAPIClient.ts
+++ b/src/internals/BaseAPIClient.ts
@@ -3,7 +3,7 @@ import { mapConfig, mapState } from './config-helper';
 import * as  fs from 'fs';
 import { AttachmentsResponse } from '../AccountingAPI-responses';
 
-enum AppType {
+export enum AppType {
 	Public = 'public',
 	Private = 'private',
 	Partner = 'partner'

--- a/src/internals/BaseAPIClient.ts
+++ b/src/internals/BaseAPIClient.ts
@@ -3,13 +3,19 @@ import { mapConfig, mapState } from './config-helper';
 import * as  fs from 'fs';
 import { AttachmentsResponse } from '../AccountingAPI-responses';
 
+enum AppType {
+	Public = 'public',
+	Private = 'private',
+	Partner = 'partner'
+}
+
 /**
  * TODO: Add support for the following keys:
  *
  * - PrivateKeyPassword
  */
 export interface XeroClientConfiguration {
-	appType: 'public' | 'private' | 'partner';
+	appType: AppType;
 	consumerKey: string;
 	consumerSecret: string;
 	privateKeyPath?: string;

--- a/src/internals/__tests__/config-helper.tests.ts
+++ b/src/internals/__tests__/config-helper.tests.ts
@@ -1,4 +1,4 @@
-import { ApiConfiguration, XeroClientConfiguration } from '../BaseAPIClient';
+import { ApiConfiguration, XeroClientConfiguration, AppType } from '../BaseAPIClient';
 import { mapConfig, mapState } from '../config-helper';
 import { testCertString, validTestCertPath } from './helpers/privateKey-helpers';
 const version = require('../../../package.json').version;
@@ -7,7 +7,7 @@ describe('config-helper', () => {
 	describe('Private apps', () => {
 		describe('with cert as a path', () => {
 			const xeroConfigWithCertPath: XeroClientConfiguration = {
-				appType: 'private',
+				appType: AppType.Private,
 				consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 				consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 				privateKeyPath: validTestCertPath()
@@ -43,7 +43,7 @@ describe('config-helper', () => {
 
 		describe('with cert as a string', () => {
 			const xeroConfigWithCertPath: XeroClientConfiguration = {
-				appType: 'private',
+				appType: AppType.Private,
 				consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 				consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 				privateKeyString: testCertString()
@@ -82,7 +82,7 @@ describe('config-helper', () => {
 	describe('Public apps', () => {
 
 		const xeroConfig: XeroClientConfiguration = {
-			appType: 'public',
+			appType: AppType.Public,
 			consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 			consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 			privateKeyPath: validTestCertPath()
@@ -117,7 +117,7 @@ describe('config-helper', () => {
 
 		describe('with cert as a path', () => {
 			const xeroConfig: XeroClientConfiguration = {
-				appType: 'partner',
+				appType: AppType.Partner,
 				consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 				consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 				privateKeyPath: validTestCertPath()
@@ -150,7 +150,7 @@ describe('config-helper', () => {
 
 		describe('with cert as a string', () => {
 			const xeroConfig: XeroClientConfiguration = {
-				appType: 'partner',
+				appType: AppType.Partner,
 				consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 				consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 				privateKeyString: testCertString()
@@ -187,7 +187,7 @@ describe('config-helper', () => {
 
 		describe('with cert as path', () => {
 			const xeroConfig: XeroClientConfiguration = {
-				appType: 'partner',
+				appType: AppType.Partner,
 				consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 				consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 				privateKeyPath: validTestCertPath()
@@ -218,7 +218,7 @@ describe('config-helper', () => {
 
 		describe('with user agent set', () => {
 			const xeroConfig: XeroClientConfiguration = {
-				appType: 'partner',
+				appType: AppType.Partner,
 				userAgent: 'PHILWASHERE',
 				consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 				consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
@@ -250,7 +250,7 @@ describe('config-helper', () => {
 
 		describe('with cert as string', () => {
 			const xeroConfig: XeroClientConfiguration = {
-				appType: 'partner',
+				appType: AppType.Partner,
 				consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 				consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 				privateKeyString: testCertString()

--- a/src/internals/__tests__/error-handling.tests.ts
+++ b/src/internals/__tests__/error-handling.tests.ts
@@ -1,5 +1,5 @@
 import { TestAPIClient } from './helpers/TestAPIClient';
-import { BaseAPIClient, XeroClientConfiguration } from '../BaseAPIClient';
+import { BaseAPIClient, XeroClientConfiguration, AppType } from '../BaseAPIClient';
 import { validTestCertPath } from './helpers/privateKey-helpers';
 import { XeroError } from '../../XeroError';
 import { OAuth1HttpClient, OAuth1Configuration, AccessToken, RequestToken } from '../OAuth1HttpClient';
@@ -34,7 +34,7 @@ describe('HTTP errors', () => {
 		oauth_session_handle: 'sessionHandle'
 	};
 	const xeroConfig: XeroClientConfiguration = {
-		appType: 'private',
+		appType: AppType.Private,
 		consumerKey: 'RDGDV41TRLQZDFSDX96TKQ2KRJIW4C',
 		consumerSecret: 'DJ3CMGDB0DIIA9DNEEJMRLZG0BWE7Y',
 		privateKeyPath: validTestCertPath()


### PR DESCRIPTION
Proposal to add appType a Enum type since typescript refuses to compile because 
Types of property 'appType' are incompatible. Type 'string' is not assignable to type '"private" | "public" | "partner"'