### PR TITLE
client refactor & issue cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
 # Change Log
 ---------
 
+
+## "version": "4.1.0"
+
+Naming Conventions updated - Open API spec only allows us to to single PUT/POST in our generated SDKS - refactoring to enable the supported endpoints. This is a larger change that will enable the generated SDK's to be encompass the full features of the raw API, but does require some painful re-naming.
+
+Semver naming -> MAJOR.MINOR.PATCH
+
+While this is not a backwards compatible change, we are opting to bounce this to 4.1.0 as the current sdk is relatively new and is getting to a more stable palce.
+
+ex:
+`createContact` -> `updateOrCreateContacts`
+`createBankTransaction` -> `updateOrCreateBankTransactions`
+
+This will enable the ability for our SDK's to both batch create/update from a single endpoint based on the payload..
+
+Refer to the generated type files to see the newly expected format of each function.
+
+Remove singular create methods
+* createItem
+* createContact
+* createBankTransaction
+* createInvoice
+* createPurchaseOrder
+
+Add createOrUpdate bulk methods
+* updateOrCreateItems
+* updateOrCreateContacts
+* updateOrCreateBankTransactions
+* updateOrCreateInvoices
+* createPurchaseOrders
+
+* Add summarizeError to bulk create and updateOrCreate methods
+
+* Add missing Enums from
+- taxRates
+
+* Fix datatype for DiscountRate from string to number on lineItem model
+
+* Add object IDs to ValidationError element array
+
+* Add statusAttributeString to Contact model
+
+
 ## "version": "4.0.7"
 
 1) Persists client in the constructor so you can access `openIdClient` without having to call `buildConsentUrl()`

--- a/src/xeroClient.ts
+++ b/src/xeroClient.ts
@@ -1,125 +1,123 @@
-import { Issuer, TokenSet, custom, } from 'openid-client';
+import { Issuer, TokenSet } from 'openid-client';
 import * as xero from './gen/api';
 import request = require('request');
 import http = require('http');
 
 export interface IXeroClientConfig {
-    clientId: string,
-    clientSecret: string,
-    redirectUris: string[],
-    scopes: string[],
-    state?: string
+  clientId: string,
+  clientSecret: string,
+  redirectUris: string[],
+  scopes: string[],
+  state?: string
 }
 
 export class XeroClient {
 
-    constructor(private readonly config: IXeroClientConfig) {
-        // need to set access token before use
-        this.accountingApi = new xero.AccountingApi(); 
-        this.buildClient()
+  constructor(private readonly config: IXeroClientConfig) {
+    // need to set access token before use
+    this.accountingApi = new xero.AccountingApi(); 
+    this.buildClient()
+  }
+
+  private tokenSet: TokenSet = new TokenSet
+  private _tenantIds: string[] = ['']
+
+  readonly accountingApi: xero.AccountingApi;
+
+  private openIdClient: any; // from openid-client
+  
+  get tenantIds(): string[] {
+    return this._tenantIds;
+  }
+
+  async buildClient() {
+    const issuer = await Issuer.discover('https://identity.xero.com');
+    this.openIdClient = new issuer.Client({
+      client_id: this.config.clientId,
+      client_secret: this.config.clientSecret,
+      redirect_uris: this.config.redirectUris,
+    });
+    this.openIdClient.CLOCK_TOLERANCE = 5; // to allow a 5 second skew in the openid-client validations
+  }
+
+  async buildConsentUrl() {
+    this.openIdClient.authorizationUrl({
+      redirect_uri: this.config.redirectUris[0],
+      scope: this.config.scopes.join(' ') || 'openid email profile'
+    });
+  }
+
+  async setAccessTokenFromRedirectUri(url: string) {
+    const params = this.openIdClient.callbackParams(url)
+    const check = {...params}
+    this.tokenSet = await this.openIdClient.callback(this.config.redirectUris[0], params, check);
+    this.setAccessTokenForAllApis();
+
+    await this.fetchConnectedTenantIds();
+  }
+
+  async readIdTokenClaims() {
+    return this.tokenSet.claims();
+  }
+
+  async readTokenSet() {
+    return this.tokenSet;
+  }
+
+  async setTokenSet(savedTokens: TokenSet) {
+    this.tokenSet = savedTokens;
+    this.setAccessTokenForAllApis();
+  }
+
+  async refreshToken() {
+    if (!this.tokenSet) {
+      throw new Error('tokenSet is not defined');
     }
+    this.tokenSet = await this.openIdClient.refresh(this.tokenSet.refresh_token);
+    this.setAccessTokenForAllApis();
 
-    private tokenSet: TokenSet = new TokenSet
-    private _tenantIds: string[] = ['']
+    await this.fetchConnectedTenantIds();
+  }
 
-    readonly accountingApi: xero.AccountingApi;
+  async fetchConnectedTenantIds() {
+    // retrieve the authorized tenants from api.xero.com/connections
+    const result = await new Promise<{ response: http.IncomingMessage; body: Array<{ id: string, tenantId: string, tenantType: string }> }>((resolve, reject) => {
+      request({
+          method: 'GET',
+          uri: 'https://api.xero.com/connections',
+          auth: {
+              bearer: this.tokenSet.access_token
+          },
+          json: true
+      }, (error, response, body) => {
+          if (error) {
+              reject(error);
+          } else {
+              if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
+                  resolve({ response: response, body: body });
+              } else {
+                  reject({ response: response, body: body });
+              }
+          }
+      });
+    });
 
-    private openIdClient: any; // from openid-client
+    result.body.map(connection => console.log('connection: ',connection));
+
+    this._tenantIds = result.body.map(connection => connection.tenantId);
+
+    // Requests to the accounting api will look like this:
+    //   let apiResponse = await xeroClient.accountingApi.getInvoices(xeroClient.tenantIds[0]);
+  }
+
+  private setAccessTokenForAllApis() {
+    const accessToken = this.tokenSet.access_token;
+    if (typeof accessToken === 'undefined') {
+      throw new Error('Access token is undefined!');
+    }
     
-    get tenantIds(): string[] {
-        return this._tenantIds;
-    }
-
-    async buildClient() {
-        const issuer = await Issuer.discover('https://identity.xero.com');
-        this.openIdClient = new issuer.Client({
-            client_id: this.config.clientId,
-            client_secret: this.config.clientSecret,
-            redirect_uris: this.config.redirectUris,
-        });
-    }
-
-    async buildConsentUrl() {
-        this.openIdClient[custom.clock_tolerance] = 5; // to allow a 5 second skew in the openid-client validations
-
-        const url = this.openIdClient.authorizationUrl({
-            redirect_uri: this.config.redirectUris[0],
-            scope: this.config.scopes.join(' ') || 'openid email profile'
-        });
-
-        return url;
-    }
-
-    async setAccessTokenFromRedirectUri(url: string) {
-        const params = this.openIdClient.callbackParams(url)
-        const check = {...params}
-        this.tokenSet = await this.openIdClient.callback(this.config.redirectUris[0], params, check);
-        this.setAccessTokenForAllApis();
-
-        await this.fetchConnectedTenantIds();
-    }
-
-    async readIdTokenClaims() {
-        return this.tokenSet.claims();
-    }
-
-    async readTokenSet() {
-        return this.tokenSet;
-    }
-
-    async setTokenSet(savedTokens: TokenSet) {
-        this.tokenSet = savedTokens;
-        this.setAccessTokenForAllApis();
-    }
-
-    async refreshToken() {
-
-        if (!this.tokenSet) {
-            throw new Error('tokenSet is not defined');
-        }
-        this.tokenSet = await this.openIdClient.refresh(this.tokenSet.refresh_token);
-        this.setAccessTokenForAllApis();
-
-        await this.fetchConnectedTenantIds();
-    }
-
-    private setAccessTokenForAllApis() {
-        const accessToken = this.tokenSet.access_token;
-        if (typeof accessToken === 'undefined') {
-            throw new Error('Access token is undefined!');
-        }
-        
-        this.accountingApi.accessToken = accessToken;
-        // this.payrollApi.accessToken = accessToken;
-        // etc.
-    }
-
-    private async fetchConnectedTenantIds() {
-        // retrieve the authorized tenants from api.xero.com/connections
-        const result = await new Promise<{ response: http.IncomingMessage; body: Array<{ id: string, tenantId: string, tenantType: string }> }>((resolve, reject) => {
-            request({
-                method: 'GET',
-                uri: 'https://api.xero.com/connections',
-                auth: {
-                    bearer: this.tokenSet.access_token
-                },
-                json: true
-            }, (error, response, body) => {
-                if (error) {
-                    reject(error);
-                } else {
-                    if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve({ response: response, body: body });
-                    } else {
-                        reject({ response: response, body: body });
-                    }
-                }
-            });
-        });
-
-        this._tenantIds = result.body.map(connection => connection.tenantId);
-
-        // Requests to the accounting api will look like this:
-        //   let apiResponse = await xeroClient.accountingApi.getInvoices(xeroClient.tenantIds[0]);
-    }
+    this.accountingApi.accessToken = accessToken;
+    // this.payrollApi.accessToken = accessToken;
+    // etc.
+  }
 }


### PR DESCRIPTION
* refactor of the `buildClient()` to include the clock_tolerance custom
```
 async buildClient() {
    ...
    this.openIdClient.CLOCK_TOLERANCE = 5; // to allow a 5 second skew in the openid-client validations
  }
```
* format client file 2 spaces from 2 tabs
* `fetchConnectedTenantIds` no longer private