### PR TITLE
Update getTokenFromDatabase function on README.md to make it more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Once you have a valid token saved you can set the token on the client without go
 
 For example - once a user authenticates you can refresh the token (which will also set the new token on the client) to make authorized api calls.
 ```js
+const getTokenFromDatabase = userId => {
+  // function to fetch your user Token from DB;
+  const tokenFromDB;
+
+  // const { TokenSet } = require('openid-client');
+  return new TokenSet(tokenFromDB);
+};
+
 const tokenSet = getTokenFromDatabase(userId) // example function name
 
 await xero.setTokenSet(tokenSet)


### PR DESCRIPTION
I spent lots of hours just to find out why I couldn't check my token if it's expired or not. Turns out, I have to wrap my token from DB with TokenSet from openid-client package.

Hope this could help someone in the future that has same issue with me.