### PR TITLE
Passed state to openid-client when building consent URL

### DIFF
--- a/src/XeroClient.ts
+++ b/src/XeroClient.ts
@@ -91,7 +91,8 @@ export class XeroClient {
     if (this.config) {
       url = this.openIdClient.authorizationUrl({
         redirect_uri: this.config.redirectUris[0],
-        scope: this.config.scopes.join(' ') || 'openid email profile'
+        scope: this.config.scopes.join(' ') || 'openid email profile',
+        state: this.config.state
       });
     }
     return url;

--- a/src/test/xeroClient.spec.ts
+++ b/src/test/xeroClient.spec.ts
@@ -49,6 +49,20 @@ describe('the XeroClient', () => {
       expect(authUrl.substring(0, 49)).toEqual('https://login.xero.com/identity/connect/authorize')
     });
 
+    it('buildConsentUrl() returns the state in the auth url', async () => {
+        const authUrlWithoutState = await xero.buildConsentUrl()
+        expect(authUrlWithoutState.includes('state=12345')).not.toEqual(true);
+        const xeroWithState = new XeroClient({
+            clientId: 'YOUR_CLIENT_ID',
+            clientSecret: 'YOUR_CLIENT_SECRET',
+            redirectUris: [`http://localhost:5000/callback`],
+            scopes: 'openid profile email accounting.transactions offline_access'.split(" "),
+            state: '12345'
+        });
+        const authUrlWithState = await xeroWithState.buildConsentUrl();
+        expect(authUrlWithState.includes('state=12345')).toEqual(true);
+    });
+
     it('initialize() returns the client', async () => {
       const xeroClient = await xero.initialize()
       expect(xeroClient).toHaveProperty('accountingApi')


### PR DESCRIPTION
It doesn't look like the state which you can pass to `IXeroClientConfig` doesn't get used anywhere so this pull request passes it to `openid-client` when calling `buildConsentUrl()`.

I've also added a test in to make sure it's working as expected, test could be made shorter by changing the original Xero object but I wasn't sure how you'd feel about it.

Let me know if I missed anything you need!