### PR TITLE
Timeout Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,17 @@ Populate the XeroClient's active tenant data
 
 For most integrations you will always want to display the org name and additional metadata about the connected org. The `/connections` endpoint does not currently serialize that data so requires developers to make additional api calls for each org that your user connects to surface that information.
 
-The `updatedTenants` function will query & nest the additional orgData results in your xeroClient under each connection/tenant object and return the array of tenants. This requires `accounting.settings` scope because `updateTenants` calls the organisation endpoint.
+
+Calling `await xero.updateTenants()` will query the /connections endpoint and store the resulting information on the client. It has an optional parameter named `fullOrgDetails` that defaults to true.
+
+Calling `await xero.updateTenants()` will query & nest the additional orgData results in your xeroClient under each connection/tenant object by hitting the /organisation endpoint fore each of your connections which will require the `accounting.settings` scope.
+
+If you don't need additional org data (like currency, shortCode, etc) the `tenantName` will still be accessible on the `.tenants` function. Call the helper with false param `await xero.updateTenants(false)` and this will not kick off additional org meta data calls.
 
 ```js
+// updateTenants fullOrgDetails param will default to true
 const tenants = await xero.updateTenants()
-
-console.log(tenants || xero.tenants)
+console.log(xero.tenants)
 [
   {
     id: 'xxx-yyy-zzz-xxx-yyy',
@@ -134,6 +139,7 @@ console.log(tenants || xero.tenants)
     tenantType: 'ORGANISATION',
     createdDateUtc: 'UTC-DateString',
     updatedDateUtc: 'UTC-DateString',
+    tenantName: 'Demo Company (US)',
     orgData: {
       organisationID: 'xxx-yyy-zzz-xxx-yyy',
       name: 'My first org',
@@ -141,20 +147,20 @@ console.log(tenants || xero.tenants)
       shortCode: '!2h37s',
       ...
     }
-  },
+  }
+]
+
+// if you pass false, the client will not fetch additional metadata about each org connection
+const tenants = await xero.updateTenants(false)
+console.log(xero.tenants)
+[
   {
     id: 'xxx-yyy-zzz-xxx-yyy',
     tenantId: 'xxx-yyy-zzz-xxx-yyy',
     tenantType: 'ORGANISATION',
     createdDateUtc: 'UTC-DateString',
     updatedDateUtc: 'UTC-DateString',
-    orgData: {
-      organisationID: 'xxx-yyy-zzz-xxx-yyy',
-      name: 'My second org',
-      version: 'AUS',
-      shortCode: '!yrcgp',
-      ...
-    }
+    tenantName: 'Demo Company (US)'
   }
 ]
 

--- a/README.md
+++ b/README.md
@@ -117,16 +117,13 @@ The `tokenSet` is what you should store in your database. That object is what yo
 
 ## Step 3 (convenience step)
 
-Populate the XeroClient's active tenant data
+Populate the XeroClient's active tenant data.
 
-For most integrations you will always want to display the org name and additional metadata about the connected org. The `/connections` endpoint does not currently serialize that data so requires developers to make additional api calls for each org that your user connects to surface that information.
+For most integrations you will want to display the org name and use additional metadata about the connected org. The `/connections` endpoint does not currently serialize all org metadata so requires developers to make an additional calls for each org that your user connects to get information like default currency.
 
+Calling `await xero.updateTenants()` will query the /connections endpoint and store the resulting information on the client. It has an optional parameter named `fullOrgDetails` that defaults to `true`. If you do not pass `false` to this function you will need to have the `accounting.settings` scope on your token as the `/organisation` endpoint that is called, requires it.
 
-Calling `await xero.updateTenants()` will query the /connections endpoint and store the resulting information on the client. It has an optional parameter named `fullOrgDetails` that defaults to true.
-
-Calling `await xero.updateTenants()` will query & nest the additional orgData results in your xeroClient under each connection/tenant object by hitting the /organisation endpoint fore each of your connections which will require the `accounting.settings` scope.
-
-If you don't need additional org data (like currency, shortCode, etc) the `tenantName` will still be accessible on the `.tenants` function. Call the helper with false param `await xero.updateTenants(false)` and this will not kick off additional org meta data calls.
+If you don't need additional org data (like currency, shortCode, etc) calling the helper with false param `await xero.updateTenants(false)` will not kick off additional org meta data calls.
 
 ```js
 // updateTenants fullOrgDetails param will default to true

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `tokenSet` is what you should store in your database. That object is what yo
 
 Populate the XeroClient's active tenant data.
 
-For most integrations you will want to display the org name and use additional metadata about the connected org. The `/connections` endpoint does not currently serialize all org metadata so requires developers to make an additional calls for each org that your user connects to get information like default currency.
+For most integrations you will want to display the org name and use additional metadata about the connected org. The `/connections` endpoint does not currently serialize all org metadata so requires developers to make an additional call for each org your user connects to get information like default currency.
 
 Calling `await xero.updateTenants()` will query the /connections endpoint and store the resulting information on the client. It has an optional parameter named `fullOrgDetails` that defaults to `true`. If you do not pass `false` to this function you will need to have the `accounting.settings` scope on your token as the `/organisation` endpoint that is called, requires it.
 
@@ -260,6 +260,27 @@ const invoices = {
 };
 
 const createdInvoice = await xero.accountingApi.createInvoices(activeTenantId, invoices)
+
+---
+
+// getting files as PDF
+const getAsPdf = await xero.accountingApi.getPurchaseOrderAsPdf(
+  req.session.activeTenant.tenantId,
+  getPurchaseOrdersResponse.body.purchaseOrders[0].purchaseOrderID,
+  { headers: { accept: 'application/pdf' } }
+)
+
+// CREATE ATTACHMENT
+const filename = "xero-dev.png";
+const pathToUpload = path.resolve(__dirname, "../public/images/xero-dev.png");
+const readStream = fs.createReadStream(pathToUpload);
+const contentType = mime.lookup(filename);
+
+const accountAttachmentsResponse: any = await xero.accountingApi.createAccountAttachmentByFileName(req.session.activeTenant.tenantId, accountId, filename, readStream, {
+  headers: {
+    'Content-Type': contentType
+  }
+});
 ```
 
 # Sample App

--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ const xero = new XeroClient({
   clientId: 'YOUR_CLIENT_ID',
   clientSecret: 'YOUR_CLIENT_SECRET',
   redirectUris: [`http://localhost:${port}/callback`],
-  scopes: 'openid profile email accounting.transactions offline_access'.split(" ")
+  scopes: 'openid profile email accounting.transactions offline_access'.split(" "),
+  state: 'returnPage=my-sweet-dashboard', // custom params (optional)
+  httpTimeout: 3000 // ms (optional)
 });
 
-// `buildConsentUrl()` calls `await xero.initialize()`
+// `buildConsentUrl()` will also call `await xero.initialize()`
 let consentUrl = await xero.buildConsentUrl();
 
 res.redirect(consentUrl);

--- a/src/XeroClient.ts
+++ b/src/XeroClient.ts
@@ -47,10 +47,6 @@ export interface XeroAccessToken {
   amr: string[]
 }
 
-interface UpdateTenantParams {
-  fullOrgDetails: boolean
-}
-
 export class XeroClient {
   constructor(private readonly config?: IXeroClientConfig) {
     this.accountingApi = new xero.AccountingApi();

--- a/src/test/mocks/connectionsResponse.json
+++ b/src/test/mocks/connectionsResponse.json
@@ -3,6 +3,7 @@
     "id": "1234",
     "tenantId": "1234",
     "tenantType": "ORGANISATION",
+    "tenantName": "Demo Company (US)",
     "createdDateUtc": "2020-01-08T19:50:42.8073030",
     "updatedDateUtc": "2020-01-08T19:50:42.8099500"
   },
@@ -10,6 +11,7 @@
     "id": "1234",
     "tenantId": "1234",
     "tenantType": "ORGANISATION",
+    "tenantName": "Demo Company (NZ)",
     "createdDateUtc": "2020-01-08T19:50:42.8073030",
     "updatedDateUtc": "2020-01-08T19:50:42.8099500"
   }

--- a/src/test/xeroClient.spec.ts
+++ b/src/test/xeroClient.spec.ts
@@ -63,6 +63,18 @@ describe('the XeroClient', () => {
         expect(authUrlWithState.includes('state=12345')).toEqual(true);
     });
 
+    it('allows for the configuration of the openid-client httpTimeout', async () => {
+      const xeroWithConfig = new XeroClient({
+        clientId: 'YOUR_CLIENT_ID',
+        clientSecret: 'YOUR_CLIENT_SECRET',
+        redirectUris: [`http://localhost:5000/callback`],
+        scopes: 'openid profile email accounting.transactions offline_access'.split(" "),
+        httpTimeout: 3000
+      });
+      const xeroClient = await xeroWithConfig.initialize()
+      expect(xeroClient.config.httpTimeout).toEqual(3000)
+    });
+
     it('initialize() returns the client', async () => {
       const xeroClient = await xero.initialize()
       expect(xeroClient).toHaveProperty('accountingApi')

--- a/src/test/xeroClient.spec.ts
+++ b/src/test/xeroClient.spec.ts
@@ -72,7 +72,7 @@ describe('the XeroClient', () => {
         httpTimeout: 3000
       });
       const xeroClient = await xeroWithConfig.initialize()
-      expect(xeroClient.config.httpTimeout).toEqual(3000)
+      expect(xeroClient['config']['httpTimeout']).toEqual(3000)
     });
 
     it('initialize() returns the client', async () => {
@@ -97,7 +97,14 @@ describe('the XeroClient', () => {
 
     it('updateTenants() returns tenant data, nests orgData, & is accessible on the client', async () => {
       const tenants = await xero.updateTenants()
-      expect(tenants[0].orgData).toEqual(getOrganisationResponse.body.organisations[0])
+      expect(tenants[0].tenantName).toEqual('Demo Company (US)')
+      expect(xero.tenants[0]).toEqual(tenants[0])
+      expect(connect.isDone()).toBe(true)
+    });
+
+    it('updateTenants(false) returns basic /connections data accessible on the client', async () => {
+      const tenants = await xero.updateTenants(false)
+      expect(tenants[0].orgData).toEqual(undefined)
       expect(xero.tenants[0]).toEqual(tenants[0])
       expect(connect.isDone()).toBe(true)
     });


### PR DESCRIPTION
This PR fixes two bugs.

1) It adds a non breaking change to the `updatedTenants` function that allows you to still get the `/connections` data on the client without having to have the `accoutning.settings` scope that calls the `/organisations` endpoint for each of your active connections. #452 

A community member who had > 600 org connections discovered this to be a bug as it made 600 async calls.. The new params defaults true but if you pass `.updateTenants(false)` it won't do that call.

This was possible because the /connections endpoint now returns the `tenantName` which was not always the case.

2) Allows for configuration of max timeout of the GOT lib openid uses, and sets the default timeout to `2500 ms` #448 