### PR TITLE
Added tenantId to queryApi as rest header

### DIFF
--- a/src/XeroClient.ts
+++ b/src/XeroClient.ts
@@ -224,11 +224,14 @@ export class XeroClient {
     return tenants;
   }
 
-  async queryApi(method, uri) {
+  async queryApi(method, uri, tenantId?: string) {
     return new Promise<{ response: http.IncomingMessage; body: Array<{ id: string, tenantId: string, tenantName: string, tenantType: string, orgData: any }> }>((resolve, reject) => {
       request({
         method,
         uri,
+        headers: {
+          "xero-tenant-id": tenantId
+        },
         auth: {
           bearer: this.tokenSet.access_token
         },


### PR DESCRIPTION
In reference to #494 which I submitted as an issue earlier.
I've just added an optional parameter to include a tenant id, and then used that in the request header.

I'm not much of an OSS developer so be as rough as possible so I can learn :)