### PR TITLE
Remove unnecessary preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git://github.com/XeroAPI/xero-node.git"
   },
   "scripts": {
+    "prepare": "npx npm-force-resolutions",
     "build": "tsc",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "git://github.com/XeroAPI/xero-node.git"
   },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
     "build": "tsc",
     "test": "jest"
   },


### PR DESCRIPTION
This causes problems for people consuming your library, as seen in issue
https://github.com/XeroAPI/xero-node/issues/505

I guess this script is only expected to run on local preinstall during dev, that's what `prepare` has been introduced some time ago: https://docs.npmjs.com/cli/v7/using-npm/scripts