### PR TITLE
Fix a potential issue which would cause the callback to fail due to `callbackParams of undefined` error

### DIFF
--- a/src/XeroClient.ts
+++ b/src/XeroClient.ts
@@ -117,6 +117,10 @@ export class XeroClient {
   }
 
   public async apiCallback(callbackUrl: string): Promise<TokenSet> {
+    if (!this.openIdClient) {
+      await this.initialize();
+    }
+
     const params = this.openIdClient.callbackParams(callbackUrl);
     const check = { state: this.config.state };
     if (this.config.scopes.includes('openid')) {


### PR DESCRIPTION
In many cases, xeroClient might not be the same instance for the following two calls

1. xeroClient.buildConsentUrl()
2. xeroClient.apiCallback()

Where `this.initialize();` is called in `xeroClient.buildConsentUrl()`, but not in `xeroClient.apiCallback()`