### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xero-node",
-  "version": "9.3.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xero-node",
-      "version": "9.3.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",


### PR DESCRIPTION
Faced issue when performing `npm ci` on node SDK because there was a version mismatch of packages in `package.json` and `package-lock.json`. So, updated the `package-lock.json` file with the latest package versions.