### PR TITLE
fix: add missing BatchPayment mapping to BankTransaction

### DIFF
--- a/src/gen/model/accounting/bankTransaction.ts
+++ b/src/gen/model/accounting/bankTransaction.ts
@@ -1,4 +1,5 @@
 import { Account } from '././account';
+import { BatchPayment } from '././batchPayment';
 import { Contact } from '././contact';
 import { CurrencyCode } from '././currencyCode';
 import { LineAmountTypes } from '././lineAmountTypes';
@@ -10,6 +11,7 @@ export class BankTransaction {
     * See Bank Transaction Types
     */
     'type': BankTransaction.TypeEnum;
+    'batchPayment'?: BatchPayment;
     'contact'?: Contact;
     /**
     * See LineItems
@@ -90,6 +92,11 @@ export class BankTransaction {
             "name": "type",
             "baseName": "Type",
             "type": "BankTransaction.TypeEnum"
+        },
+        {
+            "name": "batchPayment",
+            "baseName": "BatchPayment",
+            "type": "BatchPayment"
         },
         {
             "name": "contact",

--- a/src/test/bankTransaction.spec.ts
+++ b/src/test/bankTransaction.spec.ts
@@ -1,0 +1,15 @@
+import { BankTransaction } from '../gen/model/accounting/bankTransaction';
+
+describe('BankTransaction', () => {
+	it('includes BatchPayment in the attribute map', () => {
+		expect(BankTransaction.getAttributeTypeMap()).toEqual(
+			expect.arrayContaining([
+				{
+					name: 'batchPayment',
+					baseName: 'BatchPayment',
+					type: 'BatchPayment',
+				},
+			]),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add the missing `batchPayment` field to `BankTransaction`
- include the `BatchPayment` -> `batchPayment` attribute map entry so API responses deserialize it
- add regression coverage for the attribute map

## Why
Issue #776 reports that `BankTransaction` responses include `BatchPayment`, but the SDK model does not expose it. The generated `Payment` model already includes the same nested type, so this is a model-mapping gap rather than a new feature.

## Validation
- `npm test -- --runInBand`
- `npm run build`

Closes #776
