### PR TITLE
fix: preserve string-typed invoice dates during deserialization

### DIFF
--- a/src/gen/model/accounting/models.ts
+++ b/src/gen/model/accounting/models.ts
@@ -579,12 +579,7 @@ export class ObjectSerializer {
         if (data == undefined) {
             return data;
         } else if (primitives.indexOf(type.toLowerCase()) !== -1) {
-            if (type === "string" && data.toString().substring(0, 6) === "/Date(") {
-                return this.deserializeDateFormats(type, data) // For MS dates that are of type 'string'
-            }
-            else {
-                return data;
-            }
+            return data;
         } else if (type.lastIndexOf("Array<", 0) === 0) { // string.startsWith pre es6
             let subType: string = type.replace("Array<", ""); // Array<Type> => Type>
             subType = subType.substring(0, subType.length - 1); // Type> => Type

--- a/src/test/objectSerializer.spec.ts
+++ b/src/test/objectSerializer.spec.ts
@@ -1,0 +1,16 @@
+import { ObjectSerializer } from '../gen/model/accounting/models';
+
+describe('ObjectSerializer', () => {
+  it('preserves invoice date fields as strings during deserialization', () => {
+    const invoice = ObjectSerializer.deserialize(
+      {
+        Date: '/Date(1743638400000+0000)/',
+        DueDate: '/Date(1743724800000+0000)/',
+      },
+      'Invoice',
+    );
+
+    expect(invoice.date).toBe('/Date(1743638400000+0000)/');
+    expect(invoice.dueDate).toBe('/Date(1743724800000+0000)/');
+  });
+});


### PR DESCRIPTION
## Summary
- stop deserializing string-typed accounting fields into `Date` objects
- preserve invoice `date` and `dueDate` exactly as string values when the model type says `string`
- add regression coverage for invoice deserialization

## Why
Issue #746 reports that paged invoice responses populate `Invoice.date` and `Invoice.dueDate` as runtime `Date` objects even though the SDK model types declare them as `string`. The root cause is the generic accounting deserializer special-casing `/Date(...)` string values and converting them to `Date` even when the target field type is `string`.

Keeping string-typed fields as strings preserves the declared TypeScript contract and avoids implicit timezone interpretation on date-only values.

## Validation
- `npm test -- --runInBand`
- `npm run build`

Closes #746
