### PR TITLE
fix: reject xero-node API failures as Error objects

### DIFF
--- a/src/gen/api/accountingApi.ts
+++ b/src/gen/api/accountingApi.ts
@@ -200,7 +200,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -310,7 +310,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -420,7 +420,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -502,7 +502,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -587,7 +587,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -662,7 +662,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -771,7 +771,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -853,7 +853,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -933,7 +933,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1015,7 +1015,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1097,7 +1097,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1206,7 +1206,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1281,7 +1281,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1363,7 +1363,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1445,7 +1445,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1525,7 +1525,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1612,7 +1612,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1727,7 +1727,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1809,7 +1809,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1894,7 +1894,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1969,7 +1969,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2051,7 +2051,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2126,7 +2126,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2241,7 +2241,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2323,7 +2323,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2408,7 +2408,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2490,7 +2490,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2575,7 +2575,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2650,7 +2650,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2760,7 +2760,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2842,7 +2842,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2922,7 +2922,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3009,7 +3009,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3091,7 +3091,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3166,7 +3166,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3248,7 +3248,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3323,7 +3323,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3403,7 +3403,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3490,7 +3490,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3572,7 +3572,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3682,7 +3682,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3764,7 +3764,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3844,7 +3844,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3954,7 +3954,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4036,7 +4036,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4116,7 +4116,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4196,7 +4196,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4306,7 +4306,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4388,7 +4388,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4498,7 +4498,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4580,7 +4580,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4660,7 +4660,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4735,7 +4735,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4810,7 +4810,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4892,7 +4892,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4966,7 +4966,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5041,7 +5041,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5123,7 +5123,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5204,7 +5204,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5277,7 +5277,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5358,7 +5358,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5432,7 +5432,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5506,7 +5506,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5587,7 +5587,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5669,7 +5669,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5750,7 +5750,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5824,7 +5824,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5905,7 +5905,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5987,7 +5987,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6061,7 +6061,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6149,7 +6149,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6237,7 +6237,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6311,7 +6311,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6390,7 +6390,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6469,7 +6469,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6557,7 +6557,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6645,7 +6645,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6719,7 +6719,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6813,7 +6813,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6887,7 +6887,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -6961,7 +6961,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7049,7 +7049,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7137,7 +7137,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7211,7 +7211,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7285,7 +7285,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7364,7 +7364,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7438,7 +7438,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7512,7 +7512,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7591,7 +7591,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7665,7 +7665,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7739,7 +7739,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7806,7 +7806,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7890,7 +7890,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -7972,7 +7972,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8046,7 +8046,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8134,7 +8134,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8222,7 +8222,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8296,7 +8296,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8370,7 +8370,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8444,7 +8444,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8518,7 +8518,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8595,7 +8595,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8669,7 +8669,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8778,7 +8778,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8857,7 +8857,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -8931,7 +8931,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9019,7 +9019,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9107,7 +9107,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9181,7 +9181,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9255,7 +9255,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9349,7 +9349,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9426,7 +9426,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9500,7 +9500,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9574,7 +9574,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9653,7 +9653,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9732,7 +9732,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9806,7 +9806,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9894,7 +9894,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -9982,7 +9982,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10056,7 +10056,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10130,7 +10130,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10197,7 +10197,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10331,7 +10331,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10410,7 +10410,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10484,7 +10484,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10568,7 +10568,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10642,7 +10642,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10716,7 +10716,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10795,7 +10795,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10869,7 +10869,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -10966,7 +10966,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11040,7 +11040,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11128,7 +11128,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11216,7 +11216,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11290,7 +11290,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11379,7 +11379,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11453,7 +11453,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11527,7 +11527,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11594,7 +11594,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11668,7 +11668,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11735,7 +11735,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11809,7 +11809,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11883,7 +11883,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -11982,7 +11982,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12056,7 +12056,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12130,7 +12130,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12197,7 +12197,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12286,7 +12286,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12360,7 +12360,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12434,7 +12434,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12533,7 +12533,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12607,7 +12607,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12681,7 +12681,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12769,7 +12769,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12857,7 +12857,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -12931,7 +12931,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13005,7 +13005,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13079,7 +13079,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13178,7 +13178,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13252,7 +13252,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13326,7 +13326,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13414,7 +13414,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13502,7 +13502,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13576,7 +13576,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13650,7 +13650,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13764,7 +13764,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13843,7 +13843,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -13931,7 +13931,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14019,7 +14019,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14093,7 +14093,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14167,7 +14167,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14251,7 +14251,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14325,7 +14325,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14413,7 +14413,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14501,7 +14501,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14575,7 +14575,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14649,7 +14649,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14726,7 +14726,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14818,7 +14818,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -14910,7 +14910,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15012,7 +15012,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15089,7 +15089,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15171,7 +15171,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15243,7 +15243,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15317,7 +15317,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15434,7 +15434,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15506,7 +15506,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15583,7 +15583,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15650,7 +15650,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15724,7 +15724,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15801,7 +15801,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15883,7 +15883,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -15957,7 +15957,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16031,7 +16031,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16110,7 +16110,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16185,7 +16185,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16267,7 +16267,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16377,7 +16377,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16464,7 +16464,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16574,7 +16574,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16683,7 +16683,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16765,7 +16765,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16874,7 +16874,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -16956,7 +16956,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17043,7 +17043,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17153,7 +17153,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17235,7 +17235,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17322,7 +17322,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17432,7 +17432,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17519,7 +17519,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17601,7 +17601,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17683,7 +17683,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17793,7 +17793,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17878,7 +17878,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -17958,7 +17958,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18043,7 +18043,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18128,7 +18128,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18213,7 +18213,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18293,7 +18293,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18373,7 +18373,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18453,7 +18453,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18533,7 +18533,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18615,7 +18615,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18725,7 +18725,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18807,7 +18807,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -18917,7 +18917,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -19004,7 +19004,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -19114,7 +19114,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -19196,7 +19196,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -19306,7 +19306,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -19381,7 +19381,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -19463,7 +19463,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -19552,7 +19552,7 @@ export class AccountingApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/appStoreApi.ts
+++ b/src/gen/api/appStoreApi.ts
@@ -146,7 +146,7 @@ export class AppStoreApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -213,7 +213,7 @@ export class AppStoreApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -295,7 +295,7 @@ export class AppStoreApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -384,7 +384,7 @@ export class AppStoreApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/assetApi.ts
+++ b/src/gen/api/assetApi.ts
@@ -153,7 +153,7 @@ export class AssetApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -228,7 +228,7 @@ export class AssetApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -302,7 +302,7 @@ export class AssetApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -369,7 +369,7 @@ export class AssetApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -436,7 +436,7 @@ export class AssetApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -538,7 +538,7 @@ export class AssetApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/bankfeedsApi.ts
+++ b/src/gen/api/bankfeedsApi.ts
@@ -152,7 +152,7 @@ export class BankFeedsApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -228,7 +228,7 @@ export class BankFeedsApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -303,7 +303,7 @@ export class BankFeedsApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -377,7 +377,7 @@ export class BankFeedsApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -454,7 +454,7 @@ export class BankFeedsApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -528,7 +528,7 @@ export class BankFeedsApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -610,7 +610,7 @@ export class BankFeedsApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/filesApi.ts
+++ b/src/gen/api/filesApi.ts
@@ -159,7 +159,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -234,7 +234,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -307,7 +307,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -387,7 +387,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -460,7 +460,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -554,7 +554,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -631,7 +631,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -705,7 +705,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -779,7 +779,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -853,7 +853,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -940,7 +940,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1014,7 +1014,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1086,7 +1086,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1153,7 +1153,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1235,7 +1235,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1317,7 +1317,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1422,7 +1422,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1534,7 +1534,7 @@ export class FilesApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/financeApi.ts
+++ b/src/gen/api/financeApi.ts
@@ -183,7 +183,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -265,7 +265,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -337,7 +337,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -414,7 +414,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -501,7 +501,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -588,7 +588,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -665,7 +665,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -737,7 +737,7 @@ export class FinanceApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/payrollAUApi.ts
+++ b/src/gen/api/payrollAUApi.ts
@@ -170,7 +170,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -245,7 +245,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -320,7 +320,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -395,7 +395,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -470,7 +470,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -545,7 +545,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -620,7 +620,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -695,7 +695,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -769,7 +769,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -853,7 +853,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -927,7 +927,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1011,7 +1011,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1095,7 +1095,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1179,7 +1179,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1253,7 +1253,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1337,7 +1337,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1411,7 +1411,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1495,7 +1495,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1569,7 +1569,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1636,7 +1636,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1710,7 +1710,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1787,7 +1787,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1871,7 +1871,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1945,7 +1945,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2029,7 +2029,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2105,7 +2105,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2187,7 +2187,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2269,7 +2269,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2351,7 +2351,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2433,7 +2433,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2515,7 +2515,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2597,7 +2597,7 @@ export class PayrollAuApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/payrollAUV2Api.ts
+++ b/src/gen/api/payrollAUV2Api.ts
@@ -155,7 +155,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -230,7 +230,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -312,7 +312,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -386,7 +386,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -467,7 +467,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -541,7 +541,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -638,7 +638,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -714,7 +714,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -803,7 +803,7 @@ export class PayrollAuV2Api {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/payrollNZApi.ts
+++ b/src/gen/api/payrollNZApi.ts
@@ -214,7 +214,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -289,7 +289,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -364,7 +364,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -439,7 +439,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -521,7 +521,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -603,7 +603,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -685,7 +685,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -767,7 +767,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -849,7 +849,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -931,7 +931,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1013,7 +1013,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1095,7 +1095,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1177,7 +1177,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1252,7 +1252,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1334,7 +1334,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1409,7 +1409,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1484,7 +1484,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1559,7 +1559,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1634,7 +1634,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1709,7 +1709,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1791,7 +1791,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1872,7 +1872,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1953,7 +1953,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2034,7 +2034,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2115,7 +2115,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2189,7 +2189,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2270,7 +2270,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2344,7 +2344,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2416,7 +2416,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2490,7 +2490,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2562,7 +2562,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2636,7 +2636,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2710,7 +2710,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2794,7 +2794,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2868,7 +2868,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2942,7 +2942,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3016,7 +3016,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3090,7 +3090,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3164,7 +3164,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3245,7 +3245,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3324,7 +3324,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3398,7 +3398,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3479,7 +3479,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3553,7 +3553,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3630,7 +3630,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3704,7 +3704,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3781,7 +3781,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3855,7 +3855,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3929,7 +3929,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4001,7 +4001,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4078,7 +4078,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4152,7 +4152,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4234,7 +4234,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4308,7 +4308,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4380,7 +4380,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4447,7 +4447,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4521,7 +4521,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4593,7 +4593,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4667,7 +4667,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4739,7 +4739,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4813,7 +4813,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4910,7 +4910,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4977,7 +4977,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5053,7 +5053,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5135,7 +5135,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5224,7 +5224,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5313,7 +5313,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5402,7 +5402,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5484,7 +5484,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5566,7 +5566,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5655,7 +5655,7 @@ export class PayrollNzApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/payrollUKApi.ts
+++ b/src/gen/api/payrollUKApi.ts
@@ -210,7 +210,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -285,7 +285,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -360,7 +360,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -435,7 +435,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -510,7 +510,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -592,7 +592,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -674,7 +674,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -756,7 +756,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -838,7 +838,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -920,7 +920,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1002,7 +1002,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1077,7 +1077,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1159,7 +1159,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1234,7 +1234,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1316,7 +1316,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1391,7 +1391,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1466,7 +1466,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1541,7 +1541,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1623,7 +1623,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1703,7 +1703,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1784,7 +1784,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1864,7 +1864,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1938,7 +1938,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2019,7 +2019,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2093,7 +2093,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2165,7 +2165,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2239,7 +2239,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2311,7 +2311,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2385,7 +2385,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2457,7 +2457,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2531,7 +2531,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2603,7 +2603,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2677,7 +2677,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2758,7 +2758,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2832,7 +2832,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2916,7 +2916,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -2990,7 +2990,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3064,7 +3064,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3138,7 +3138,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3212,7 +3212,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3286,7 +3286,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3367,7 +3367,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3446,7 +3446,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3530,7 +3530,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3604,7 +3604,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3678,7 +3678,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3755,7 +3755,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3829,7 +3829,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3906,7 +3906,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -3980,7 +3980,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4054,7 +4054,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4126,7 +4126,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4203,7 +4203,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4277,7 +4277,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4359,7 +4359,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4433,7 +4433,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4505,7 +4505,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4572,7 +4572,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4651,7 +4651,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4725,7 +4725,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4822,7 +4822,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4889,7 +4889,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -4965,7 +4965,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5047,7 +5047,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5136,7 +5136,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5225,7 +5225,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5307,7 +5307,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5396,7 +5396,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -5485,7 +5485,7 @@ export class PayrollUkApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/gen/api/projectApi.ts
+++ b/src/gen/api/projectApi.ts
@@ -160,7 +160,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -242,7 +242,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -324,7 +324,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -405,7 +405,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -486,7 +486,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -560,7 +560,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -637,7 +637,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -729,7 +729,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -810,7 +810,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -904,7 +904,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1028,7 +1028,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1109,7 +1109,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1191,7 +1191,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1273,7 +1273,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1362,7 +1362,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });
@@ -1451,7 +1451,7 @@ export class ProjectApi {
                 }
                 catch(error) {
                      const errorResponse = new ApiError(error)
-					 reject(JSON.stringify(errorResponse.generateError()))
+					 reject(errorResponse.toError())
                 }
             });
         });

--- a/src/model/ApiError.ts
+++ b/src/model/ApiError.ts
@@ -23,7 +23,7 @@ interface ErrorResponse {
 	body: any
 }
 
-export class ApiError {
+export class ApiError extends Error {
 
 	statusCode: number
 	body: any
@@ -31,6 +31,8 @@ export class ApiError {
 	request: Request
 
 	constructor(axiosError) {
+		super('Xero API request failed');
+		this.name = 'ApiError';
 
         this.statusCode = axiosError.response.status;
 		this.body = axiosError.response.data;
@@ -57,5 +59,25 @@ export class ApiError {
 			},
 			body: this.body
 		};
+	}
+
+	toError(): Error & ErrorResponse & { statusCode: number; headers: any; request: Request } {
+		const error = this as unknown as Error & ErrorResponse & {
+			statusCode: number;
+			headers: any;
+			request: Request;
+		};
+		error.response = {
+			statusCode: this.statusCode,
+			body: this.body,
+			headers: this.headers,
+			request: this.request,
+		};
+		error.body = this.body;
+		error.message =
+			typeof this.body === 'string'
+				? this.body
+				: `Xero API request failed with status ${this.statusCode}`;
+		return error;
 	}
 }

--- a/src/test/apiError.spec.ts
+++ b/src/test/apiError.spec.ts
@@ -1,0 +1,33 @@
+import { ApiError } from '../model/ApiError';
+
+describe('ApiError', () => {
+	it('can convert to an Error object with response details attached', () => {
+		const apiError = new ApiError({
+			response: {
+				status: 404,
+				data: 'Not Found',
+				headers: {
+					'content-type': 'text/plain',
+				},
+			},
+			request: {
+				protocol: 'https:',
+				socket: {
+					localPort: 443,
+				},
+				host: 'api.xero.com',
+				path: '/api.xro/2.0/Invoices/not-found',
+				getHeaders: () => ({}),
+				method: 'GET',
+			},
+		});
+
+		const error = apiError.toError();
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe('ApiError');
+		expect(error.message).toBe('Not Found');
+		expect(error.response.statusCode).toBe(404);
+		expect(error.body).toBe('Not Found');
+	});
+});


### PR DESCRIPTION
## Summary
- reject SDK promise failures as `Error` objects instead of JSON strings
- keep the structured Xero response attached on the error object for downstream inspection
- add regression coverage for the new `ApiError.toError()` path

## Why
Issues #500 and #741 both point at the same behavior: API failures are surfaced as non-Error rejections, and in newer paths they can even become plain strings via `JSON.stringify(...)`. That breaks standard promise/error handling flows and strips away normal `Error` behavior like `name`, `message`, and stack handling.

This change keeps the structured response payload, but wraps it in a real `Error` instance so callers can handle failures predictably.

## Validation
- `npm test -- --runInBand`
- `npm run build`

Closes #741
