### PR TITLE
ci: run build-lint-test workflow on pull_request events

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -2,6 +2,7 @@ name: Node Build, Lint and Test
 
 on:
     push:
+    pull_request:
 
 jobs:
     build-test-lint:
@@ -11,13 +12,12 @@ jobs:
             - name: Checkout xero-node repo
               uses: actions/checkout@v4
               with:
-                repository: XeroAPI/xero-node
                 path: xero-node
 
             - name: Set up Node environment
               uses: actions/setup-node@v4
               with:
-                node-version: 20
+                node-version: 24
                 cache: 'npm'
                 cache-dependency-path: '**/package-lock.json'
 


### PR DESCRIPTION
The workflow only triggered on push, so it never ran on PRs from forks (checks showed "no checks reported" on PR #807). The checkout step also pinned repository: XeroAPI/xero-node with no ref, which would have checked out master instead of the PR head once triggered. Also bumps node-version to 24 to match the recently updated publish workflow.